### PR TITLE
This fixes function assignment with expressions containing Constants

### DIFF
--- a/dolfin_adjoint_common/blocks/function.py
+++ b/dolfin_adjoint_common/blocks/function.py
@@ -73,13 +73,14 @@ class FunctionAssignBlock(Block):
 
         expr = prepared
         dudm = self.backend.Function(block_variable.output.function_space())
+        dudmi = self.backend.Function(block_variable.output.function_space())
         for dep in self.get_dependencies():
             if dep.tlm_value:
-                dudmi = ufl.algorithms.expand_derivatives(
+                dudmi.assign(ufl.algorithms.expand_derivatives(
                     ufl.derivative(expr, dep.saved_output,
-                                   dep.tlm_value)
-                )
-                dudm += dudmi
+                                   dep.tlm_value)))
+                dudm.vector().axpy(1.0, dudmi.vector())
+
         return dudm
 
     def prepare_evaluate_hessian(self, inputs, hessian_inputs, adj_inputs,

--- a/dolfin_adjoint_common/blocks/function.py
+++ b/dolfin_adjoint_common/blocks/function.py
@@ -8,9 +8,11 @@ class FunctionAssignBlock(Block):
         super().__init__()
         self.other = None
         self.expr = None
+        if isinstance(other, float) or isinstance(other, int):
+            other = AdjFloat(other)
         if isinstance(other, OverloadedType):
             self.add_dependency(other, no_duplicates=True)
-        else:
+        elif not(isinstance(other, float) or isinstance(other, int)):
             # Assume that this is a point-wise evaluated UFL expression (firedrake only)
             for op in traverse_unique_terminals(other):
                 if isinstance(op, OverloadedType):

--- a/tests/firedrake_adjoint/test_assignment.py
+++ b/tests/firedrake_adjoint/test_assignment.py
@@ -5,6 +5,7 @@ from firedrake import *
 from firedrake_adjoint import *
 
 from numpy.random import rand
+from numpy.testing import assert_approx_equal, assert_allclose
 
 
 def test_assign_linear_combination():
@@ -71,6 +72,30 @@ def test_assign_tlm():
     assert taylor_test(rf, f, h, dJdm=J.tlm_value) > 1.9
 
 
+def test_assign_tlm_wit_constant():
+    mesh = IntervalMesh(10, 0, 1)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    x = SpatialCoordinate(mesh)
+    f = interpolate(x[0], V)
+    g = interpolate(sin(x[0]), V)
+    c = Constant(5.0)
+
+    u = Function(V)
+    u.assign(c * f ** 2)
+
+    c.tlm_value = Constant(0.3)
+    tape = get_working_tape()
+    tape.evaluate_tlm()
+    assert_allclose(u.block_variable.tlm_value.dat.data, 0.3 * f.dat.data ** 2)
+
+    tape.reset_tlm_values()
+    c.tlm_value = Constant(0.4)
+    f.tlm_value = g
+    tape.evaluate_tlm()
+    assert_allclose(u.block_variable.tlm_value.dat.data, 0.4 * f.dat.data ** 2 + 10. * f.dat.data * g.dat.data)
+
+
 def test_assign_hessian():
     mesh = UnitSquareMesh(10, 10)
     element = VectorElement("CG", mesh.ufl_cell(), degree=1, dim=2)
@@ -112,6 +137,29 @@ def test_assign_nonlincom():
     h.vector()[:] = rand(V.dim())
     assert taylor_test(rf, f, h) > 1.9
 
+
+def test_assign_with_constant():
+    mesh = IntervalMesh(10, 0, 1)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    x = SpatialCoordinate(mesh)
+    f = interpolate(x[0], V)
+    c = Constant(3.0)
+    d = Constant(2.0)
+    u = Function(V)
+
+    u.assign(c*f+d**3)
+
+    # J = c**2/3 + cd**3 + d**6
+    J = assemble(u ** 2 * dx)
+
+    rf = ReducedFunctional(J, Control(c))
+    dJdc = rf.derivative()
+    assert_approx_equal(float(dJdc), 10.)
+
+    rf = ReducedFunctional(J, Control(d))
+    dJdd = rf.derivative()
+    assert_approx_equal(float(dJdd), 228.)
 
 def test_assign_nonlin_changing():
     mesh = IntervalMesh(10, 0, 1)

--- a/tests/firedrake_adjoint/test_assignment.py
+++ b/tests/firedrake_adjoint/test_assignment.py
@@ -69,6 +69,7 @@ def test_assign_tlm():
     tape = get_working_tape()
     tape.evaluate_tlm()
 
+    assert J.tlm_value is not None
     assert taylor_test(rf, f, h, dJdm=J.tlm_value) > 1.9
 
 


### PR DESCRIPTION
Firedrake supports assignment with UFL expressions that can be evaluated
pointwise (in the same Functionspace). The annotation of these
previously failed to treat Constants as dependencies and compute the
relevant derivatives.