### PR TITLE
Use equispaced coordinate function space in firedrake tests

### DIFF
--- a/tests/firedrake_adjoint/test_dynamic_meshes.py
+++ b/tests/firedrake_adjoint/test_dynamic_meshes.py
@@ -6,7 +6,7 @@ import numpy as np
 
 @pytest.mark.parametrize("mesh", [UnitSquareMesh(10,10)])
 def test_dynamic_meshes_2D(mesh):
-    S = VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     s = [Function(S), Function(S), Function(S)]
     mesh.coordinates.assign(mesh.coordinates + s[0])
 
@@ -59,7 +59,7 @@ def test_dynamic_meshes_2D(mesh):
                                   TorusMesh(25,10, 1, 0.5),
                                   CylinderMesh(10,25, radius=0.5, depth=0.8)])
 def test_dynamic_meshes_3D(mesh):
-    S = VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     s = [Function(S), Function(S), Function(S)]
     mesh.coordinates.assign(mesh.coordinates + s[0])
 

--- a/tests/firedrake_adjoint/test_shape_derivatives.py
+++ b/tests/firedrake_adjoint/test_shape_derivatives.py
@@ -9,7 +9,7 @@ def test_sin_weak_spatial():
     mesh = UnitOctahedralSphereMesh(2)
     x = SpatialCoordinate(mesh)
     mesh.init_cell_orientations(x)
-    S = VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     s = Function(S)
     mesh.coordinates.assign(mesh.coordinates + s)
     
@@ -28,7 +28,7 @@ def test_tlm_assemble():
     tape.clear_tape()
     mesh = UnitCubeMesh(4,4,4)
     x = SpatialCoordinate(mesh)
-    S =  VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     h = Function(S)
     A = 10
     h.interpolate(as_vector((A*cos(x[1]), A*x[1], x[2]*x[1])))
@@ -64,7 +64,7 @@ def test_shape_hessian():
     mesh = UnitIcosahedralSphereMesh(3)
     x = SpatialCoordinate(mesh)
     mesh.init_cell_orientations(x)
-    S = VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     s = Function(S,name="deform")
 
     mesh.coordinates.assign(mesh.coordinates + s)
@@ -95,7 +95,7 @@ def test_PDE_hessian_neumann():
     x = SpatialCoordinate(mesh)
     mesh.init_cell_orientations(x)
 
-    S = VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     s = Function(S,name="deform")
     mesh.coordinates.assign(mesh.coordinates + s)
     f = x[0]*x[1]*x[2]
@@ -147,7 +147,7 @@ def test_PDE_hessian_dirichlet():
 
     x = SpatialCoordinate(mesh)
 
-    S = VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     s = Function(S,name="deform")
     mesh.coordinates.assign(mesh.coordinates + s)
     f = x[0]*x[1]*x[2]
@@ -198,7 +198,7 @@ def test_multiple_assignments():
     tape.clear_tape()
 
     mesh = UnitSquareMesh(5, 5)
-    S = VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     s = Function(S)
 
     mesh.coordinates.assign(mesh.coordinates + s)
@@ -230,7 +230,7 @@ def test_multiple_assignments():
     tape.clear_tape()
 
     mesh = UnitSquareMesh(5, 5)
-    S = VectorFunctionSpace(mesh, "CG", 1)
+    S = mesh.coordinates.function_space()
     s = Function(S)
     mesh.coordinates.assign(mesh.coordinates + 2*s)
 


### PR DESCRIPTION
Firedrake now uses equispaced function spaces for mesh coordinates which breaks firedrake adjoint tests. This PR fixes the function spaces definition in the tests.