### PR TITLE
Remove deprecated block variable interface

### DIFF
--- a/examples/tube-shape-derivative/tube-shape-derivative.py
+++ b/examples/tube-shape-derivative/tube-shape-derivative.py
@@ -63,6 +63,7 @@ set_log_level(LogLevel.ERROR)
 fout = File("output/u.pvd")
 mesh = Mesh("mesh/cable1.xml")
 bdy_markers = MeshFunction("size_t", mesh, "mesh/cable1_facet_region.xml")
+original_mesh = Control(mesh)
 
 # Then, we define the discrete function spaces. A piecewise linear
 # approximation is a suitable choice for the the solution of the advection-diffusion equation.
@@ -219,7 +220,7 @@ pprint(conv)
 # Finally, we store the shape derivative for visualisation:
 
 dJdm = Jhat.derivative()
-ALE.move(mesh, Function(V), reset_mesh=True)
+mesh.coordinates()[:] = original_mesh.data()
 
 output = File("output/dJdOmega.pvd")
 out = Function(V)

--- a/fenics_adjoint/types/constant.py
+++ b/fenics_adjoint/types/constant.py
@@ -41,9 +41,6 @@ class Constant(OverloadedType, backend.Constant):
     def get_derivative(self, options={}):
         return self._ad_convert_type(self.adj_value, options=options)
 
-    def adj_update_value(self, value):
-        self.original_block_variable.checkpoint = value._ad_create_checkpoint()
-
     def _ad_convert_type(self, value, options={}):
         if value is None:
             # TODO: Should the default be 0 constant here or return just None?

--- a/fenics_adjoint/types/function.py
+++ b/fenics_adjoint/types/function.py
@@ -185,10 +185,6 @@ class Function(FloatingType, backend.Function):
         return checkpoint
 
     @no_annotations
-    def adj_update_value(self, value):
-        self.original_block_variable.checkpoint = value._ad_create_checkpoint()
-
-    @no_annotations
     def _ad_mul(self, other):
         r = get_overloaded_class(backend.Function)(self.function_space())
         backend.Function.assign(r, self * other)

--- a/fenics_adjoint/types/io.py
+++ b/fenics_adjoint/types/io.py
@@ -12,8 +12,6 @@ def HDF5File_read(self, *args, **kwargs):
 
     if annotate:
         func = args[0]
-        if isinstance(func, backend.Mesh):
-            func.org_mesh_coords = func.coordinates().copy()
         if isinstance(func, OverloadedType):
             func.create_block_variable()
     return output
@@ -31,8 +29,6 @@ def XDMFFile_read(self, *args, **kwargs):
 
     if annotate:
         func = args[0]
-        if isinstance(func, backend.Mesh):
-            func.org_mesh_coords = func.coordinates().copy()
         if isinstance(func, OverloadedType):
             func.create_block_variable()
     return output

--- a/fenics_adjoint/types/mesh.py
+++ b/fenics_adjoint/types/mesh.py
@@ -18,12 +18,6 @@ class Mesh(OverloadedType, backend.Mesh):
         super(Mesh, self).__init__(*args, **kwargs)
         backend.Mesh.__init__(self, *args, **kwargs)
 
-        if self.num_vertices() >= 1:
-            # If the mesh is not empty, save the original coordinates
-            self.org_mesh_coords = self.coordinates().copy()
-        else:
-            self.org_mesh_coords = None
-
         self._ad_coordinate_space = None
 
     def _ad_create_checkpoint(self):
@@ -72,7 +66,6 @@ def overloaded_mesh(mesh_class):
             # Calling constructor
             super(OverloadedMesh, self).__init__(*args, **kwargs)
             mesh_class.__init__(self, *args, **kwargs)
-            self.org_mesh_coords = self.coordinates().copy()
             self._ad_coordinate_space = None
 
         def _ad_create_checkpoint(self):
@@ -107,7 +100,6 @@ def overloaded_create(mesh_class):
         mesh = __ad_create(*args, **kwargs)
         mesh.__class__ = Mesh
         mesh.__init__()
-        mesh.org_mesh_coords = mesh.coordinates().copy()
 
         return mesh
     create.__doc__ = __ad_create.__doc__
@@ -125,10 +117,6 @@ __backend_ALE_move = backend.ALE.move
 
 def move(mesh, vector, **kwargs):
     annotate = annotate_tape(kwargs)
-    reset = kwargs.pop("reset_mesh", False)
-    if reset:
-        mesh.coordinates()[:] = mesh.org_mesh_coords
-        mesh.block_variable = mesh.original_block_variable
     if annotate:
         assert isinstance(mesh, OverloadedType)
         assert isinstance(vector, OverloadedType)

--- a/numpy_adjoint/array.py
+++ b/numpy_adjoint/array.py
@@ -19,9 +19,6 @@ class ndarray(OverloadedType, numpy.ndarray):
     def _ad_restore_at_checkpoint(self, checkpoint):
         return checkpoint
 
-    def adj_update_value(self, value):
-        self[:] = value
-
     def __getitem__(self, item):
         annotate = annotate_tape()
         if annotate:

--- a/pyadjoint/adjfloat.py
+++ b/pyadjoint/adjfloat.py
@@ -94,9 +94,6 @@ class AdjFloat(OverloadedType, float):
     def _ad_convert_type(self, value, options={}):
         return AdjFloat(value)
 
-    def adj_update_value(self, value):
-        self.original_block_variable.checkpoint = value
-
     def _ad_create_checkpoint(self):
         # Floats are immutable.
         return self

--- a/pyadjoint/control.py
+++ b/pyadjoint/control.py
@@ -84,12 +84,28 @@ class Control(object):
         return self.control._ad_copy()
 
     @property
+    def adj_value(self):
+        return self.block_variable.adj_value
+
+    @adj_value.setter
+    def adj_value(self, value):
+        self.block_variable.adj_value = value
+
+    @property
     def tlm_value(self):
         return self.block_variable.tlm_value
 
     @tlm_value.setter
     def tlm_value(self, value):
         self.block_variable.tlm_value = value
+
+    @property
+    def hessian_value(self):
+        return self.block_variable.hessian_value
+
+    @hessian_value.setter
+    def hessian_value(self, value):
+        self.block_variable.hessian_value = value
 
     def __getattr__(self, item):
         return getattr(self.control, item)

--- a/pyadjoint/drivers.py
+++ b/pyadjoint/drivers.py
@@ -21,7 +21,7 @@ def compute_gradient(J, m, options=None, tape=None, adj_value=1.0):
     options = {} if options is None else options
     tape = get_working_tape() if tape is None else tape
     tape.reset_variables()
-    J.adj_value = adj_value
+    J.block_variable.adj_value = adj_value
     m = Enlist(m)
 
     with stop_annotating():

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -77,7 +77,8 @@ class OverloadedType(object):
     """
 
     def __init__(self, *args, **kwargs):
-        self.original_block_variable = self.create_block_variable()
+        self.block_variable = None
+        self.create_block_variable()
 
     @classmethod
     def _ad_init_object(cls, obj):
@@ -98,22 +99,6 @@ class OverloadedType(object):
     def create_block_variable(self):
         self.block_variable = BlockVariable(self)
         return self.block_variable
-
-    @property
-    def adj_value(self):
-        return self.original_block_variable.adj_value
-
-    @adj_value.setter
-    def adj_value(self, value):
-        self.block_variable.adj_value = value
-
-    @property
-    def tlm_value(self):
-        return self.original_block_variable.tlm_value
-
-    @tlm_value.setter
-    def tlm_value(self, value):
-        self.original_block_variable.tlm_value = value
 
     def _ad_convert_type(self, value, options={}):
         """This method must be overridden.

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -71,9 +71,6 @@ class OverloadedType(object):
     it can be referenced by blocks as well as overload basic mathematical
     operations such as __mul__, __add__, where they are needed.
 
-    Abstract methods:
-        :func:`adj_update_value`
-
     """
 
     def __init__(self, *args, **kwargs):
@@ -141,18 +138,6 @@ class OverloadedType(object):
 
         Returns:
             :obj:`OverloadedType`: The object with same state as at the supplied checkpoint.
-
-        """
-        raise NotImplementedError
-
-    def adj_update_value(self, value):
-        """This method must be overridden.
-
-        The method should implement a routine for assigning a new value
-        to the overloaded object.
-
-        Args:
-            value (:obj:`object`): Should be an instance of the OverloadedType.
 
         """
         raise NotImplementedError

--- a/pyadjoint/verification.py
+++ b/pyadjoint/verification.py
@@ -112,8 +112,6 @@ def taylor_to_dict(J, m, h):
 
         Jm = J(m)
         print("Computing derivative")
-        for (hi, mi) in zip(hs, ms):
-            mi.tlm_value = hi.tlm_value
         ds = Enlist(J.derivative())
         if len(ds) != len(ms):
             raise ValueError("The derivative of J depends on {0:d} variables"

--- a/tests/fenics_adjoint/shape_hessian.py
+++ b/tests/fenics_adjoint/shape_hessian.py
@@ -33,7 +33,7 @@ r0 = taylor_test(Jhat, s, h, dJdm=0)
 Jhat(s)
 assert(r0>0.95)
 # First order taylor
-s.tlm_value = h
+s.block_variable.tlm_value = h
 tape.evaluate_tlm()
 r1 = taylor_test(Jhat, s, h, dJdm=J.block_variable.tlm_value)
 assert(r1>1.95)
@@ -75,7 +75,7 @@ Jhat(s)
 # Jhat(s)
 
 # # First order taylor
-# s.tlm_value = h
+# s.block_variable.tlm_value = h
 # tape.evaluate_tlm()
 # taylor_test(Jhat, s, h, dJdm=J.block_variable.tlm_value)
 # Jhat(s)

--- a/tests/fenics_adjoint/test_ale_shape_derivatives.py
+++ b/tests/fenics_adjoint/test_ale_shape_derivatives.py
@@ -69,7 +69,7 @@ def test_tlm_assemble():
     assert(r0 >0.95)
     Jhat(s)
     # Tangent linear model
-    s.tlm_value = h
+    s.block_variable.tlm_value = h
     tape = get_working_tape()
     tape.evaluate_tlm()
     r1_tlm = taylor_test(Jhat, s, h, dJdm=J.block_variable.tlm_value)
@@ -137,7 +137,7 @@ def test_PDE_hessian():
     Jhat(s)
     assert(r0>0.95)
     # First order taylor
-    s.tlm_value = h
+    s.block_variable.tlm_value = h
     tape = get_working_tape()
     tape.evaluate_tlm()
     r1 = taylor_test(Jhat, s, h, dJdm=J.block_variable.tlm_value)
@@ -156,7 +156,7 @@ def test_repeated_movement():
     S = VectorFunctionSpace(mesh, "CG", 1)
     s0 = Function(S)
     ALE.move(mesh, s0)
-    ALE.move(mesh, s0, reset_mesh=False)
+    ALE.move(mesh, s0)
 
     x = SpatialCoordinate(mesh)
     V = FunctionSpace(mesh, "CG", 1)

--- a/tests/fenics_adjoint/test_assignment.py
+++ b/tests/fenics_adjoint/test_assignment.py
@@ -60,12 +60,12 @@ def test_assign_tlm():
 
     h = Function(V)
     h.vector()[:] = rand(V.dim())
-    f.tlm_value = h
+    f.block_variable.tlm_value = h
 
     tape = get_working_tape()
     tape.evaluate_tlm()
 
-    assert taylor_test(rf, f, h, dJdm=J.tlm_value) > 1.9
+    assert taylor_test(rf, f, h, dJdm=J.block_variable.tlm_value) > 1.9
 
 
 def test_assign_hessian():

--- a/tests/fenics_adjoint/test_dynamic_meshes.py
+++ b/tests/fenics_adjoint/test_dynamic_meshes.py
@@ -4,11 +4,10 @@ from dolfin_adjoint import *
 import numpy as np
 
 
-@pytest.mark.parametrize("reset", [True, False])
 @pytest.mark.parametrize("mesh", [UnitSquareMesh(10,10),
                                   UnitDiscMesh.create(MPI.comm_world,
                                                       10, 1, 2)])
-def test_dynamic_meshes_2D(mesh, reset):
+def test_dynamic_meshes_2D(mesh):
     S = VectorFunctionSpace(mesh, "CG", 1)
     s = [Function(S), Function(S), Function(S)]
     ALE.move(mesh, s[0])
@@ -17,7 +16,7 @@ def test_dynamic_meshes_2D(mesh, reset):
     V = FunctionSpace(mesh, "CG", 1)
     u0 = project(cos(pi*x[0])*sin(pi*x[1]), V)
     
-    ALE.move(mesh, s[1], reset_mesh=reset)
+    ALE.move(mesh, s[1])
     
     u, v = TrialFunction(V), TestFunction(V)
     f = cos(x[0]) + x[1] * sin(2 * pi * x[1])
@@ -30,7 +29,7 @@ def test_dynamic_meshes_2D(mesh, reset):
     solve(lhs(F) == rhs(F), u1)
     J = float(dt)*assemble(u1**2*dx)
 
-    ALE.move(mesh, s[2],reset_mesh=reset)
+    ALE.move(mesh, s[2])
     F = k*inner(u-u1, v)*dx + inner(grad(u), grad(v))*dx - f*v*dx
     u2 = Function(V)
     solve(lhs(F) == rhs(F), u2)
@@ -54,10 +53,9 @@ def test_dynamic_meshes_2D(mesh, reset):
     assert(np.mean(results["R2"]["Rate"])>2.9)
 
 
-@pytest.mark.parametrize("reset", [True, False])
 @pytest.mark.parametrize("mesh", [UnitCubeMesh(4,4,4),
                                   BoxMesh(Point(0,1,2),Point(1.5,2,2.5), 4,3,5)])
-def test_dynamic_meshes_3D(mesh, reset):
+def test_dynamic_meshes_3D(mesh):
     S = VectorFunctionSpace(mesh, "CG", 1)
     s = [Function(S), Function(S), Function(S)]
     ALE.move(mesh, s[0])
@@ -66,7 +64,7 @@ def test_dynamic_meshes_3D(mesh, reset):
     V = FunctionSpace(mesh, "CG", 1)
     u0 = project(cos(pi*x[0])*sin(pi*x[1])*x[2]**2, V)
     
-    ALE.move(mesh, s[1], reset_mesh=reset)
+    ALE.move(mesh, s[1])
     
     u, v = TrialFunction(V), TestFunction(V)
     f = x[2]*cos(x[0]) + x[1] * sin(2 * pi * x[1])
@@ -79,7 +77,7 @@ def test_dynamic_meshes_3D(mesh, reset):
     solve(lhs(F) == rhs(F), u1)
     J = float(dt)*assemble(u1**2*dx)
 
-    ALE.move(mesh, s[2],reset_mesh=reset)
+    ALE.move(mesh, s[2])
     F = k*inner(u-u1, v)*dx + inner(grad(u), grad(v))*dx - f*v*dx
     u2 = Function(V)
     solve(lhs(F) == rhs(F), u2)

--- a/tests/fenics_adjoint/test_expressions.py
+++ b/tests/fenics_adjoint/test_expressions.py
@@ -286,10 +286,10 @@ def _test_adjoint_constant(J, c):
         Jm = J(c)
         #tape.visualise(dot=True, filename="expr.dot")
         #import sys; sys.exit()
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdc = c.adj_value
+        dJdc = c.block_variable.adj_value
         print(dJdc)
 
         residual = abs(Jp - Jm - eps*dJdc)
@@ -319,10 +319,10 @@ def _test_adjoint(J, f):
         Jp = J(g)
         tape.clear_tape()
         Jm = J(f)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdf = f.adj_value
+        dJdf = f.block_variable.adj_value
 
         residual = abs(Jp - Jm - eps*dJdf.inner(h.vector()))
         residuals.append(residual)

--- a/tests/fenics_adjoint/test_functionassigner.py
+++ b/tests/fenics_adjoint/test_functionassigner.py
@@ -49,7 +49,7 @@ def test_function_assigner_poisson():
 
     tape = get_working_tape()
     tape.reset_tlm_values()
-    s_.tlm_value = pert
+    s_.block_variable.tlm_value = pert
     tape.evaluate_tlm()
     r1_tlm = taylor_test(Jhat, s_, pert, dJdm=J.block_variable.tlm_value)
     assert r1_tlm > 1.95

--- a/tests/fenics_adjoint/test_mesh_movement.py
+++ b/tests/fenics_adjoint/test_mesh_movement.py
@@ -25,16 +25,3 @@ def test_boundary_mesh_movement():
     v_reverse = transfer_to_boundary(v_volume, b_mesh)
     assert(allclose(assemble(inner(movement,movement)*dx),
                     assemble(inner(v_reverse, v_reverse)*dx)))
-
-def test_reset_movement():
-    mesh = UnitSquareMesh(10,10)
-    S = VectorFunctionSpace(mesh, "CG", 1)
-    movement = interpolate(Expression(("x[0]", "0"), degree=1), S)
-    s = Function(S)
-    v = interpolate(Expression(("x[0]","x[1]"),degree=1), S)
-    ALE.move(mesh, v)
-    ALE.move(mesh, s, reset_mesh=True)
-    J = assemble(1*dx(domain=mesh))
-    Jhat = ReducedFunctional(J, Control(s))
-    assert(isclose(Jhat(s), 1))
-    assert(isclose(Jhat(movement), 2))

--- a/tests/fenics_adjoint/test_solving.py
+++ b/tests/fenics_adjoint/test_solving.py
@@ -393,10 +393,10 @@ def _test_adjoint_function_boundary(J, bc, f):
         tape.clear_tape()
         bc.set_value(f)
         Jm = J(bc)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdbc = bc.adj_value
+        dJdbc = bc.block_variable.adj_value
 
         residual = abs(Jp - Jm - eps*dJdbc.inner(h.vector()))
         residuals.append(residual)
@@ -423,10 +423,10 @@ def _test_adjoint_constant_boundary(J, bc):
         tape.clear_tape()
         bc.set_value(c)
         Jm = J(bc)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdbc = bc.adj_value[0]
+        dJdbc = bc.block_variable.adj_value[0]
 
         residual = abs(Jp - Jm - eps*dJdbc.sum())
         residuals.append(residual)
@@ -453,10 +453,10 @@ def _test_adjoint_constant(J, c):
         Jp = J(c + eps*h)
         tape.clear_tape()
         Jm = J(c)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdc = c.adj_value[0]
+        dJdc = c.block_variable.adj_value[0]
         print(dJdc)
 
         residual = abs(Jp - Jm - eps*dJdc)
@@ -484,10 +484,10 @@ def _test_adjoint(J, f):
         Jp = J(f + eps*h)
         tape.clear_tape()
         Jm = J(f)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdf = f.adj_value
+        dJdf = f.block_variable.adj_value
 
         residual = abs(Jp - Jm - eps*dJdf.inner(h.vector()))
         residuals.append(residual)

--- a/tests/fenics_adjoint/test_tlm.py
+++ b/tests/fenics_adjoint/test_tlm.py
@@ -36,7 +36,7 @@ def test_tlm_assemble():
     h = Function(V)
     h.vector()[:] = rand(V.dim())
     g = f.copy(deepcopy=True)
-    f.tlm_value = h
+    f.block_variable.tlm_value = h
     tape.evaluate_tlm()
     assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
 
@@ -61,7 +61,7 @@ def test_tlm_bc():
     J = assemble(c ** 2 * u * dx)
     Jhat = ReducedFunctional(J, Control(c))
 
-    c.tlm_value = Constant(1)
+    c.block_variable.tlm_value = Constant(1)
     tape.evaluate_tlm()
 
     assert (taylor_test(Jhat, Constant(c), Constant(1), dJdm=J.block_variable.tlm_value) > 1.9)
@@ -90,7 +90,7 @@ def test_tlm_func():
     h = Function(V)
     h.vector()[:] = rand(V.dim())
     g = c.copy(deepcopy=True)
-    c.tlm_value = h
+    c.block_variable.tlm_value = h
     tape.evaluate_tlm()
 
     assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
@@ -204,7 +204,7 @@ def test_burgers():
     h = Function(V)
     h.vector()[:] = rand(V.dim())
     g = ic.copy(deepcopy=True)
-    ic.tlm_value = h
+    ic.block_variable.tlm_value = h
     tape.evaluate_tlm()
     assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
 
@@ -243,7 +243,7 @@ def test_expression():
     h = Function(V)
     h.vector()[:] = rand(V.dim())
     g = a.copy(deepcopy=True)
-    a.tlm_value = h
+    a.block_variable.tlm_value = h
     tape.evaluate_tlm()
     assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
 
@@ -272,7 +272,7 @@ def test_projection():
     J = assemble(u_**2*dx)
     Jhat = ReducedFunctional(J, Control(k))
 
-    k.tlm_value = Constant(1)
+    k.block_variable.tlm_value = Constant(1)
     tape.evaluate_tlm()
     assert(taylor_test(Jhat, Constant(k), Constant(1), dJdm=J.block_variable.tlm_value) > 1.9)
 
@@ -305,7 +305,7 @@ def test_projection_function():
     h = Function(V)
     h.vector()[:] = rand(V.dim())
     m = g.copy(deepcopy=True)
-    g.tlm_value = h
+    g.block_variable.tlm_value = h
     tape.evaluate_tlm()
     assert (taylor_test(Jhat, m, h, dJdm=J.block_variable.tlm_value) > 1.9)
 
@@ -332,7 +332,7 @@ def test_assemble_recompute():
     h = Function(V)
     h.vector()[:] = rand(V.dim())
     g = f.copy(deepcopy=True)
-    f.tlm_value = h
+    f.block_variable.tlm_value = h
     tape.evaluate_tlm()
     assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
 

--- a/tests/firedrake_adjoint/test_assignment.py
+++ b/tests/firedrake_adjoint/test_assignment.py
@@ -69,7 +69,7 @@ def test_assign_tlm():
     tape = get_working_tape()
     tape.evaluate_tlm()
 
-    assert J.tlm_value is not None
+    assert J.block_variable.tlm_value is not None
     assert taylor_test(rf, f, h, dJdm=J.block_variable.tlm_value) > 1.9
 
 
@@ -85,14 +85,14 @@ def test_assign_tlm_wit_constant():
     u = Function(V)
     u.assign(c * f ** 2)
 
-    c.tlm_value = Constant(0.3)
+    c.block_variable.tlm_value = Constant(0.3)
     tape = get_working_tape()
     tape.evaluate_tlm()
     assert_allclose(u.block_variable.tlm_value.dat.data, 0.3 * f.dat.data ** 2)
 
     tape.reset_tlm_values()
-    c.tlm_value = Constant(0.4)
-    f.tlm_value = g
+    c.block_variable.tlm_value = Constant(0.4)
+    f.block_variable.tlm_value = g
     tape.evaluate_tlm()
     assert_allclose(u.block_variable.tlm_value.dat.data, 0.4 * f.dat.data ** 2 + 10. * f.dat.data * g.dat.data)
 

--- a/tests/firedrake_adjoint/test_assignment.py
+++ b/tests/firedrake_adjoint/test_assignment.py
@@ -63,12 +63,12 @@ def test_assign_tlm():
 
     h = Function(V)
     h.vector()[:] = 1
-    f.tlm_value = h
+    f.block_variable.tlm_value = h
 
     tape = get_working_tape()
     tape.evaluate_tlm()
 
-    assert taylor_test(rf, f, h, dJdm=J.tlm_value) > 1.9
+    assert taylor_test(rf, f, h, dJdm=J.block_variable.tlm_value) > 1.9
 
 
 def test_assign_hessian():

--- a/tests/firedrake_adjoint/test_projection.py
+++ b/tests/firedrake_adjoint/test_projection.py
@@ -49,7 +49,7 @@ def test_project_tlm():
     tape = get_working_tape()
     tape.evaluate_tlm()
 
-    assert taylor_test(rf, f, h, dJdm=J.tlm_value) > 1.9
+    assert taylor_test(rf, f, h, dJdm=J.block_variable.tlm_value) > 1.9
 
 
 def test_project_hessian():

--- a/tests/firedrake_adjoint/test_shape_derivatives.py
+++ b/tests/firedrake_adjoint/test_shape_derivatives.py
@@ -47,7 +47,7 @@ def test_tlm_assemble():
     Jhat(s)
 
     # Tangent linear model
-    s.tlm_value = h
+    s.block_variable.tlm_value = h
     tape = get_working_tape()
     tape.evaluate_tlm()
     r1_tlm = taylor_test(Jhat, s, h, dJdm=J.block_variable.tlm_value)
@@ -125,7 +125,7 @@ def test_PDE_hessian_neumann():
     assert(r1>1.95)
 
     # First order taylor
-    s.tlm_value = h
+    s.block_variable.tlm_value = h
     tape = get_working_tape()
     tape.evaluate_tlm()
     r1 = taylor_test(Jhat, s, h, dJdm=J.block_variable.tlm_value)
@@ -179,7 +179,7 @@ def test_PDE_hessian_dirichlet():
     assert(r1>1.95)
 
     # First order taylor
-    s.tlm_value = h
+    s.block_variable.tlm_value = h
     tape = get_working_tape()
     tape.evaluate_tlm()
     r1 = taylor_test(Jhat, s, h, dJdm=J.block_variable.tlm_value)

--- a/tests/firedrake_adjoint/test_solving.py
+++ b/tests/firedrake_adjoint/test_solving.py
@@ -302,10 +302,10 @@ def _test_adjoint_function_boundary(J, bc, f):
         tape.clear_tape()
         bc.set_value(f)
         Jm = J(bc)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdbc = bc.adj_value
+        dJdbc = bc.block_variable.adj_value
 
         residual = abs(Jp - Jm - eps*dJdbc.inner(h.vector()))
         residuals.append(residual)
@@ -333,10 +333,10 @@ def _test_adjoint_constant_boundary(J, bc):
         tape.clear_tape()
         bc.set_value(c)
         Jm = J(bc)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdbc = bc.adj_value[0]
+        dJdbc = bc.block_variable.adj_value[0]
 
         residual = abs(Jp - Jm - eps*dJdbc.sum())
         residuals.append(residual)
@@ -362,10 +362,10 @@ def _test_adjoint_constant(J, c):
         Jp = J(c + eps*h)
         tape.clear_tape()
         Jm = J(c)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdc = c.adj_value[0]
+        dJdc = c.block_variable.adj_value[0]
         print(dJdc)
 
         residual = abs(Jp - Jm - eps*dJdc)
@@ -394,10 +394,10 @@ def _test_adjoint(J, f):
         Jp = J(f + eps*h)
         tape.clear_tape()
         Jm = J(f)
-        Jm.adj_value = 1.0
+        Jm.block_variable.adj_value = 1.0
         tape.evaluate_adj()
 
-        dJdf = f.adj_value
+        dJdf = f.block_variable.adj_value
 
         residual = abs(Jp - Jm - eps*dJdf.inner(h.vector()))
         residuals.append(residual)

--- a/tests/firedrake_adjoint/test_tlm.py
+++ b/tests/firedrake_adjoint/test_tlm.py
@@ -36,7 +36,7 @@ def test_tlm_assemble():
     h = Function(V)
     h.vector()[:] = rand(h.dof_dset.size)
     g = f.copy(deepcopy=True)
-    f.tlm_value = h
+    f.block_variable.tlm_value = h
     tape.evaluate_tlm()
     assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
 
@@ -61,7 +61,7 @@ def test_tlm_bc():
     J = assemble(c ** 2 * u * dx)
     Jhat = ReducedFunctional(J, Control(c))
 
-    c.tlm_value = Constant(1)
+    c.block_variable.tlm_value = Constant(1)
     tape.evaluate_tlm()
 
     assert (taylor_test(Jhat, Constant(c), Constant(1), dJdm=J.block_variable.tlm_value) > 1.9)
@@ -91,7 +91,7 @@ def test_tlm_func():
     h = Function(V)
     h.vector()[:] = rand(h.dof_dset.size)
     g = c.copy(deepcopy=True)
-    c.tlm_value = h
+    c.block_variable.tlm_value = h
     tape.evaluate_tlm()
 
     assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
@@ -200,7 +200,7 @@ def test_burgers():
     h = Function(V)
     h.vector()[:] = rand(h.dof_dset.size)
     g = ic.copy(deepcopy=True)
-    ic.tlm_value = h
+    ic.block_variable.tlm_value = h
     tape.evaluate_tlm()
     assert (taylor_test(Jhat, g, h, dJdm=J.block_variable.tlm_value) > 1.9)
 
@@ -229,7 +229,7 @@ def test_projection():
     J = assemble(u_**2*dx)
     Jhat = ReducedFunctional(J, Control(k))
 
-    k.tlm_value = Constant(1)
+    k.block_variable.tlm_value = Constant(1)
     tape.evaluate_tlm()
     assert(taylor_test(Jhat, Constant(k), Constant(1), dJdm=J.block_variable.tlm_value) > 1.9)
 
@@ -262,6 +262,6 @@ def test_projection_function():
     h = Function(V)
     h.vector()[:] = rand(h.dof_dset.size)
     m = g.copy(deepcopy=True)
-    g.tlm_value = h
+    g.block_variable.tlm_value = h
     tape.evaluate_tlm()
     assert (taylor_test(Jhat, m, h, dJdm=J.block_variable.tlm_value) > 1.9)


### PR DESCRIPTION
- Removes the `OverloadedType.adj_value` and `OverloadedType.tlm_value` attributes. Access block variables either directly or through the Control interface instead.
- Removes `OverloadedType.adj_update_value` method, use `Control.update` instead.
- Removes kwarg `reset_mesh` in `ALE.move`. For now, the user must manually reset the mesh. We might introduce this feature again if it is needed.

Resolves issue #25.