### PR TITLE
Adding in keep diagonal as kwarg for adjoint and forward solver.

### DIFF
--- a/dolfin_adjoint_common/blocks/solving.py
+++ b/dolfin_adjoint_common/blocks/solving.py
@@ -272,7 +272,8 @@ class GenericSolveBlock(Block):
         dFdm = ufl.algorithms.expand_derivatives(dFdm)
         dFdm = self.compat.assemble_adjoint_value(dFdm)
         dudm = self.backend.Function(V)
-        return self._assemble_and_solve_tlm_eq(self.compat.assemble_adjoint_value(dFdu, bcs=bcs), dFdm, dudm, bcs)
+        return self._assemble_and_solve_tlm_eq(
+            self.compat.assemble_adjoint_value(dFdu, bcs=bcs, **self.assemble_kwargs), dFdm, dudm, bcs)
 
     def _assemble_and_solve_tlm_eq(self, dFdu, dFdm, dudm, bcs):
         return self._assembled_solve(dFdu, dFdm, dudm, bcs)

--- a/fenics_adjoint/assembly.py
+++ b/fenics_adjoint/assembly.py
@@ -13,6 +13,8 @@ def assemble(*args, **kwargs):
     annotate = annotate_tape(kwargs)
     with stop_annotating():
         output = backend.assemble(*args, **kwargs)
+    if "keep_diagonal" in kwargs:
+        output.keep_diagonal = kwargs["keep_diagonal"]
 
     form = args[0]
     if isinstance(output, float):
@@ -42,7 +44,8 @@ def assemble_system(*args, **kwargs):
     b_form = args[1]
 
     A, b = backend.assemble_system(*args, **kwargs)
-
+    if "keep_diagonal" in kwargs:
+        A.keep_diagonal = kwargs["keep_diagonal"]
     if "bcs" in kwargs:
         bcs = kwargs["bcs"]
     elif len(args) > 2:

--- a/fenics_adjoint/blocks/lu_solver.py
+++ b/fenics_adjoint/blocks/lu_solver.py
@@ -32,7 +32,7 @@ class LUSolveBlock(SolveLinearSystemBlock):
                                              dFdu_adj_form.arguments()[0]) * backend.dx
                 A, _ = backend.assemble_system(dFdu_adj_form, rhs_bcs_form, bcs, **self.assemble_kwargs)
             else:
-                A = compat.assemble_adjoint_value(dFdu_adj_form, **assemble_kwargs)
+                A = compat.assemble_adjoint_value(dFdu_adj_form, **self.assemble_kwargs)
                 [bc.apply(A) for bc in bcs]
             if self.ident_zeros_tol is not None:
                 A.ident_zeros(self.ident_zeros_tol)
@@ -56,9 +56,9 @@ class LUSolveBlock(SolveLinearSystemBlock):
         solver = self.block_helper.forward_solver
         if solver is None:
             if self.assemble_system:
-                A, _ = backend.assemble_system(lhs, rhs, bcs, **self.assemble_kwargs )
+                A, _ = backend.assemble_system(lhs, rhs, bcs, **self.assemble_kwargs)
             else:
-                A = compat.assemble_adjoint_value(lhs, **assemble_kwargs)
+                A = compat.assemble_adjoint_value(lhs, **self.assemble_kwargs)
                 [bc.apply(A) for bc in bcs]
 
             solver = backend.LUSolver(A, self.method)

--- a/fenics_adjoint/blocks/lu_solver.py
+++ b/fenics_adjoint/blocks/lu_solver.py
@@ -27,11 +27,10 @@ class LUSolveBlock(SolveLinearSystemBlock):
 
         solver = self.block_helper.adjoint_solver
         if solver is None:
-            assemble_kwargs = self.assemble_kwargs.copy()
             if self.assemble_system:
                 rhs_bcs_form = backend.inner(backend.Function(self.function_space),
                                              dFdu_adj_form.arguments()[0]) * backend.dx
-                A, _ = backend.assemble_system(dFdu_adj_form, rhs_bcs_form, bcs, **assemble_kwargs)
+                A, _ = backend.assemble_system(dFdu_adj_form, rhs_bcs_form, bcs, **self.assemble_kwargs)
             else:
                 A = compat.assemble_adjoint_value(dFdu_adj_form, **assemble_kwargs)
                 [bc.apply(A) for bc in bcs]
@@ -56,9 +55,8 @@ class LUSolveBlock(SolveLinearSystemBlock):
     def _forward_solve(self, lhs, rhs, func, bcs, **kwargs):
         solver = self.block_helper.forward_solver
         if solver is None:
-            assemble_kwargs = self.assemble_kwargs.copy()
             if self.assemble_system:
-                A, _ = backend.assemble_system(lhs, rhs, bcs, **assemble_kwargs )
+                A, _ = backend.assemble_system(lhs, rhs, bcs, **self.assemble_kwargs )
             else:
                 A = compat.assemble_adjoint_value(lhs, **assemble_kwargs)
                 [bc.apply(A) for bc in bcs]

--- a/fenics_adjoint/blocks/lu_solver.py
+++ b/fenics_adjoint/blocks/lu_solver.py
@@ -27,13 +27,13 @@ class LUSolveBlock(SolveLinearSystemBlock):
 
         solver = self.block_helper.adjoint_solver
         if solver is None:
+            assemble_kwargs = self.assemble_kwargs.copy()
             if self.assemble_system:
-                self.keep_diagonal=False
                 rhs_bcs_form = backend.inner(backend.Function(self.function_space),
                                              dFdu_adj_form.arguments()[0]) * backend.dx
-                A, _ = backend.assemble_system(dFdu_adj_form, rhs_bcs_form, bcs, keep_diagonal=self.keep_diagonal)
+                A, _ = backend.assemble_system(dFdu_adj_form, rhs_bcs_form, bcs, **assemble_kwargs)
             else:
-                A = compat.assemble_adjoint_value(dFdu_adj_form, keep_diagonal=self.keep_diagonal)
+                A = compat.assemble_adjoint_value(dFdu_adj_form, **assemble_kwargs)
                 [bc.apply(A) for bc in bcs]
             if self.ident_zeros_tol is not None:
                 A.ident_zeros(self.ident_zeros_tol)
@@ -56,10 +56,11 @@ class LUSolveBlock(SolveLinearSystemBlock):
     def _forward_solve(self, lhs, rhs, func, bcs, **kwargs):
         solver = self.block_helper.forward_solver
         if solver is None:
+            assemble_kwargs = self.assemble_kwargs.copy()
             if self.assemble_system:
-                A, _ = backend.assemble_system(lhs, rhs, bcs, keep_diagonal=self.keep_diagonal)
+                A, _ = backend.assemble_system(lhs, rhs, bcs, **assemble_kwargs )
             else:
-                A = compat.assemble_adjoint_value(lhs, keep_diagonal=self.keep_diagonal)
+                A = compat.assemble_adjoint_value(lhs, **assemble_kwargs)
                 [bc.apply(A) for bc in bcs]
 
             solver = backend.LUSolver(A, self.method)

--- a/fenics_adjoint/blocks/solving.py
+++ b/fenics_adjoint/blocks/solving.py
@@ -10,7 +10,7 @@ class SolveLinearSystemBlock(GenericSolveBlock):
         super().__init__(lhs, rhs, func, bcs, *args, **kwargs)
 
         # Set up parameters initialization
-        self.keep_diagonal =  A.keep_diagonal if hasattr(A, "keep_diagonal") else False
+        self.assemble_kwargs["keep_diagonal"] =  A.keep_diagonal if hasattr(A, "keep_diagonal") else False
         self.ident_zeros_tol = A.ident_zeros_tol if hasattr(A, "ident_zeros_tol") else None
         self.assemble_system = A.assemble_system if hasattr(A, "assemble_system") else False
 

--- a/fenics_adjoint/blocks/solving.py
+++ b/fenics_adjoint/blocks/solving.py
@@ -115,14 +115,14 @@ class SolveVarFormBlock(GenericSolveBlock):
         solver_method = "default" if solver_method == "lu" else solver_method
 
         if solver_method in lu_solver_methods:
-            solver = self.backend.LUSolver(dFdu, method=solver_method)
+            solver = self.backend.LUSolver(solver_method)
             solver_parameters = self.adj_kwargs.get("lu_solver", {})
         else:
-            solver = self.backend.KrylovSolver(dFdu, *self.adj_args)
+            solver = self.backend.KrylovSolver( *self.adj_args)
             solver_parameters = self.adj_kwargs.get("krylov_solver", {})
 
         solver.parameters.update(solver_parameters)
-        solver.solve(adj_sol.vector(), dJdu)
+        solver.solve(dFdu, adj_sol.vector(), dJdu)
 
         adj_sol_bdy = None
         if compute_bdy:

--- a/fenics_adjoint/blocks/solving.py
+++ b/fenics_adjoint/blocks/solving.py
@@ -118,7 +118,7 @@ class SolveVarFormBlock(GenericSolveBlock):
             solver = self.backend.LUSolver(solver_method)
             solver_parameters = self.adj_kwargs.get("lu_solver", {})
         else:
-            solver = self.backend.KrylovSolver( *self.adj_args)
+            solver = self.backend.KrylovSolver(*self.adj_args)
             solver_parameters = self.adj_kwargs.get("krylov_solver", {})
 
         solver.parameters.update(solver_parameters)

--- a/fenics_adjoint/blocks/solving.py
+++ b/fenics_adjoint/blocks/solving.py
@@ -10,7 +10,7 @@ class SolveLinearSystemBlock(GenericSolveBlock):
         super().__init__(lhs, rhs, func, bcs, *args, **kwargs)
 
         # Set up parameters initialization
-        self.assemble_kwargs["keep_diagonal"] =  A.keep_diagonal if hasattr(A, "keep_diagonal") else False
+        self.assemble_kwargs["keep_diagonal"] = A.keep_diagonal if hasattr(A, "keep_diagonal") else False
         self.ident_zeros_tol = A.ident_zeros_tol if hasattr(A, "ident_zeros_tol") else None
         self.assemble_system = A.assemble_system if hasattr(A, "assemble_system") else False
 
@@ -120,7 +120,6 @@ class SolveVarFormBlock(GenericSolveBlock):
         else:
             solver = self.backend.KrylovSolver(*self.adj_args)
             solver_parameters = self.adj_kwargs.get("krylov_solver", {})
-
         solver.parameters.update(solver_parameters)
         solver.solve(dFdu, adj_sol.vector(), dJdu)
 

--- a/tests/fenics_adjoint/test_solving.py
+++ b/tests/fenics_adjoint/test_solving.py
@@ -1,8 +1,9 @@
+from fenics_adjoint import *
+from fenics import *
+
 import pytest
 pytest.importorskip("fenics")
 
-from fenics import *
-from fenics_adjoint import *
 
 def test_linear_problem():
     mesh = IntervalMesh(10, 0, 1)
@@ -17,12 +18,13 @@ def test_linear_problem():
     bc = DirichletBC(V, Constant(1), "on_boundary")
 
     def J(f):
-        a = f*inner(grad(u), grad(v))*dx
-        L = f*v*dx
+        a = f * inner(grad(u), grad(v)) * dx
+        L = f * v * dx
         solve(a == L, u_, bc)
-        return assemble(u_**2*dx)
+        return assemble(u_**2 * dx)
 
     _test_adjoint(J, f)
+
 
 def test_nonlinear_problem():
     mesh = IntervalMesh(10, 0, 1)
@@ -36,17 +38,18 @@ def test_nonlinear_problem():
     bc = DirichletBC(V, Constant(1), "on_boundary")
 
     def J(f):
-        a = f*inner(grad(u), grad(v))*dx + u**2*v*dx - f*v*dx
+        a = f * inner(grad(u), grad(v)) * dx + u**2 * v * dx - f * v * dx
         L = 0
         solve(a == L, u, bc)
-        return assemble(u**2*dx)
+        return assemble(u**2 * dx)
 
     _test_adjoint(J, f)
 
-def test_mixed_boundary():
-    mesh = UnitSquareMesh(10,10)
 
-    V = FunctionSpace(mesh,"CG",1)
+def test_mixed_boundary():
+    mesh = UnitSquareMesh(10, 10)
+
+    V = FunctionSpace(mesh, "CG", 1)
     u = TrialFunction(V)
     u_ = Function(V)
     v = TestFunction(V)
@@ -72,15 +75,15 @@ def test_mixed_boundary():
     up = Up()
     down = Down()
 
-    boundary = MeshFunction("size_t", mesh,mesh.geometric_dimension()-1)
+    boundary = MeshFunction("size_t", mesh, mesh.geometric_dimension() - 1)
     boundary.set_all(0)
     up.mark(boundary, 1)
-    down.mark(boundary,2)
+    down.mark(boundary, 2)
     ds = Measure("ds", subdomain_data=boundary)
 
-    bc1 = DirichletBC(V,Expression("x[1]*x[1]", degree=1),left)
-    bc2 = DirichletBC(V,2,right)
-    bc = [bc1,bc2]
+    bc1 = DirichletBC(V, Expression("x[1]*x[1]", degree=1), left)
+    bc2 = DirichletBC(V, 2, right)
+    bc = [bc1, bc2]
 
     g1 = Constant(2)
     g2 = Constant(1)
@@ -88,12 +91,12 @@ def test_mixed_boundary():
     f.vector()[:] = 10
 
     def J(f):
-        a = f*inner(grad(u), grad(v))*dx
-        L = inner(f,v)*dx + inner(g1,v)*ds(1) + inner(g2,v)*ds(2)
+        a = f * inner(grad(u), grad(v)) * dx
+        L = inner(f, v) * dx + inner(g1, v) * ds(1) + inner(g2, v) * ds(2)
 
-        solve(a==L,u_,bc)
+        solve(a == L, u_, bc)
 
-        return assemble(u_**2*dx)
+        return assemble(u_**2 * dx)
 
     _test_adjoint(J, f)
 
@@ -110,12 +113,13 @@ def xtest_wrt_constant_dirichlet_boundary():
     bc = DirichletBC(V, Constant(1), "on_boundary")
 
     def J(bc):
-        a = inner(grad(u), grad(v))*dx
-        L = c*v*dx
+        a = inner(grad(u), grad(v)) * dx
+        L = c * v * dx
         solve(a == L, u_, bc)
-        return assemble(u_**2*dx)
+        return assemble(u_**2 * dx)
 
     _test_adjoint_constant_boundary(J, bc)
+
 
 def _test_wrt_function_dirichlet_boundary():
     mesh = IntervalMesh(10, 0, 1)
@@ -130,18 +134,18 @@ def _test_wrt_function_dirichlet_boundary():
     bc = DirichletBC(V, f, "on_boundary")
 
     def J(bc):
-        a = inner(grad(u), grad(v))*dx
-        L = c*v*dx
+        a = inner(grad(u), grad(v)) * dx
+        L = c * v * dx
         solve(a == L, u_, bc)
-        return assemble(u_**2*dx)
+        return assemble(u_**2 * dx)
 
     _test_adjoint_function_boundary(J, bc, f)
 
 
 def xtest_wrt_function_dirichlet_boundary():
-    mesh = UnitSquareMesh(10,10)
+    mesh = UnitSquareMesh(10, 10)
 
-    V = FunctionSpace(mesh,"CG",1)
+    V = FunctionSpace(mesh, "CG", 1)
     u = TrialFunction(V)
     u_ = Function(V)
     v = TestFunction(V)
@@ -167,16 +171,16 @@ def xtest_wrt_function_dirichlet_boundary():
     up = Up()
     down = Down()
 
-    boundary = MeshFunction("size_t", mesh, mesh.geometric_dimension()-1)
+    boundary = MeshFunction("size_t", mesh, mesh.geometric_dimension() - 1)
     boundary.set_all(0)
     up.mark(boundary, 1)
-    down.mark(boundary,2)
+    down.mark(boundary, 2)
     ds = Measure("ds", subdomain_data=boundary)
 
     bc_func = project(Expression("sin(x[1])", degree=1), V)
-    bc1 = DirichletBC(V,bc_func,left)
-    bc2 = DirichletBC(V,2,right)
-    bc = [bc1,bc2]
+    bc1 = DirichletBC(V, bc_func, left)
+    bc2 = DirichletBC(V, 2, right)
+    bc = [bc1, bc2]
 
     g1 = Constant(2)
     g2 = Constant(1)
@@ -184,19 +188,20 @@ def xtest_wrt_function_dirichlet_boundary():
     f.vector()[:] = 10
 
     def J(bc):
-        a = inner(grad(u), grad(v))*dx
-        L = inner(f,v)*dx + inner(g1,v)*ds(1) + inner(g2,v)*ds(2)
+        a = inner(grad(u), grad(v)) * dx
+        L = inner(f, v) * dx + inner(g1, v) * ds(1) + inner(g2, v) * ds(2)
 
-        solve(a==L,u_,[bc,bc2])
+        solve(a == L, u_, [bc, bc2])
 
-        return assemble(u_**2*dx)
+        return assemble(u_**2 * dx)
 
     _test_adjoint_function_boundary(J, bc1, bc_func)
 
-def test_wrt_function_neumann_boundary():
-    mesh = UnitSquareMesh(10,10)
 
-    V = FunctionSpace(mesh,"CG",1)
+def test_wrt_function_neumann_boundary():
+    mesh = UnitSquareMesh(10, 10)
+
+    V = FunctionSpace(mesh, "CG", 1)
     u = TrialFunction(V)
     u_ = Function(V)
     v = TestFunction(V)
@@ -222,15 +227,15 @@ def test_wrt_function_neumann_boundary():
     up = Up()
     down = Down()
 
-    boundary = MeshFunction("size_t", mesh, mesh.geometric_dimension()-1)
+    boundary = MeshFunction("size_t", mesh, mesh.geometric_dimension() - 1)
     boundary.set_all(0)
     up.mark(boundary, 1)
-    down.mark(boundary,2)
+    down.mark(boundary, 2)
     ds = Measure("ds", subdomain_data=boundary)
 
-    bc1 = DirichletBC(V,Expression("x[1]*x[1]", degree=1),left)
-    bc2 = DirichletBC(V,2,right)
-    bc = [bc1,bc2]
+    bc1 = DirichletBC(V, Expression("x[1]*x[1]", degree=1), left)
+    bc2 = DirichletBC(V, 2, right)
+    bc = [bc1, bc2]
 
     g1 = Constant(2)
     g2 = Constant(1)
@@ -238,14 +243,15 @@ def test_wrt_function_neumann_boundary():
     f.vector()[:] = 10
 
     def J(g1):
-        a = inner(grad(u), grad(v))*dx
-        L = inner(f,v)*dx + inner(g1,v)*ds(1) + inner(g2,v)*ds(2)
+        a = inner(grad(u), grad(v)) * dx
+        L = inner(f, v) * dx + inner(g1, v) * ds(1) + inner(g2, v) * ds(2)
 
-        solve(a==L,u_,bc)
+        solve(a == L, u_, bc)
 
-        return assemble(u_**2*dx)
+        return assemble(u_**2 * dx)
 
     _test_adjoint_constant(J, g1)
+
 
 def test_wrt_constant():
     mesh = IntervalMesh(10, 0, 1)
@@ -259,17 +265,18 @@ def test_wrt_constant():
     bc = DirichletBC(V, Constant(1), "on_boundary")
 
     def J(c):
-        a = inner(grad(u), grad(v))*dx
-        L = c*v*dx
+        a = inner(grad(u), grad(v)) * dx
+        L = c * v * dx
         solve(a == L, u_, bc)
-        return assemble(u_**2*dx)
+        return assemble(u_**2 * dx)
 
     _test_adjoint_constant(J, c)
 
-def test_wrt_constant_neumann_boundary():
-    mesh = UnitSquareMesh(10,10)
 
-    V = FunctionSpace(mesh,"CG",1)
+def test_wrt_constant_neumann_boundary():
+    mesh = UnitSquareMesh(10, 10)
+
+    V = FunctionSpace(mesh, "CG", 1)
     u = TrialFunction(V)
     u_ = Function(V)
     v = TestFunction(V)
@@ -295,15 +302,15 @@ def test_wrt_constant_neumann_boundary():
     up = Up()
     down = Down()
 
-    boundary = MeshFunction("size_t", mesh, mesh.geometric_dimension()-1)
+    boundary = MeshFunction("size_t", mesh, mesh.geometric_dimension() - 1)
     boundary.set_all(0)
     up.mark(boundary, 1)
-    down.mark(boundary,2)
+    down.mark(boundary, 2)
     ds = Measure("ds", subdomain_data=boundary)
 
-    bc1 = DirichletBC(V,Expression("x[1]*x[1]", degree=1),left)
-    bc2 = DirichletBC(V,2,right)
-    bc = [bc1,bc2]
+    bc1 = DirichletBC(V, Expression("x[1]*x[1]", degree=1), left)
+    bc2 = DirichletBC(V, 2, right)
+    bc = [bc1, bc2]
 
     g1 = Constant(2)
     g2 = Constant(1)
@@ -311,31 +318,32 @@ def test_wrt_constant_neumann_boundary():
     f.vector()[:] = 10
 
     def J(g1):
-        a = inner(grad(u), grad(v))*dx
-        L = inner(f,v)*dx + inner(g1,v)*ds(1) + inner(g2,v)*ds(2)
+        a = inner(grad(u), grad(v)) * dx
+        L = inner(f, v) * dx + inner(g1, v) * ds(1) + inner(g2, v) * ds(2)
 
-        solve(a==L,u_,bc)
+        solve(a == L, u_, bc)
 
-        return assemble(u_**2*dx)
+        return assemble(u_**2 * dx)
 
     _test_adjoint_constant(J, g1)
+
 
 def test_time_dependent():
     # Defining the domain, 100 points from 0 to 1
     mesh = IntervalMesh(100, 0, 1)
 
     # Defining function space, test and trial functions
-    V = FunctionSpace(mesh,"CG",1)
+    V = FunctionSpace(mesh, "CG", 1)
     u = TrialFunction(V)
     u_ = Function(V)
     v = TestFunction(V)
 
     # Marking the boundaries
     def left(x, on_boundary):
-        return near(x[0],0)
+        return near(x[0], 0)
 
     def right(x, on_boundary):
-        return near(x[0],1)
+        return near(x[0], 1)
 
     # Dirichlet boundary conditions
     bc_left = DirichletBC(V, 1, left)
@@ -349,10 +357,10 @@ def test_time_dependent():
 
     def J(f):
         u_1 = Function(V)
-        u_1.vector()[:] = 1 
+        u_1.vector()[:] = 1
 
-        a = u_1*u*v*dx + dt*f*inner(grad(u),grad(v))*dx
-        L = u_1*v*dx
+        a = u_1 * u * v * dx + dt * f * inner(grad(u), grad(v)) * dx
+        L = u_1 * v * dx
 
         # Time loop
         t = dt
@@ -361,17 +369,19 @@ def test_time_dependent():
             u_1.assign(u_)
             t += dt
 
-        return assemble(u_1**2*dx)
+        return assemble(u_1**2 * dx)
 
     _test_adjoint_constant(J, f)
+
 
 def convergence_rates(E_values, eps_values):
     from numpy import log
     r = []
     for i in range(1, len(eps_values)):
-        r.append(log(E_values[i]/E_values[i-1])/log(eps_values[i]/eps_values[i-1]))
+        r.append(log(E_values[i] / E_values[i - 1]) / log(eps_values[i] / eps_values[i - 1]))
 
     return r
+
 
 def _test_adjoint_function_boundary(J, bc, f):
     import numpy.random
@@ -380,14 +390,14 @@ def _test_adjoint_function_boundary(J, bc, f):
 
     V = f.function_space()
     h = Function(V)
-    h.vector()[:] = 1 #numpy.random.rand(V.dim())
+    h.vector()[:] = 1  # numpy.random.rand(V.dim())
     g = Function(V)
 
-    eps_ = [0.4/2.0**i for i in range(4)]
+    eps_ = [0.4 / 2.0**i for i in range(4)]
     residuals = []
     for eps in eps_:
         #f = bc.value()
-        g.vector()[:] = f.vector()[:] + eps*h.vector()[:]
+        g.vector()[:] = f.vector()[:] + eps * h.vector()[:]
         bc.set_value(g)
         Jp = J(bc)
         tape.clear_tape()
@@ -398,14 +408,15 @@ def _test_adjoint_function_boundary(J, bc, f):
 
         dJdbc = bc.adj_value
 
-        residual = abs(Jp - Jm - eps*dJdbc.inner(h.vector()))
+        residual = abs(Jp - Jm - eps * dJdbc.inner(h.vector()))
         residuals.append(residual)
 
     r = convergence_rates(residuals, eps_)
     print(r)
 
     tol = 1E-1
-    assert( r[-1] > 2-tol )
+    assert(r[-1] > 2 - tol)
+
 
 def _test_adjoint_constant_boundary(J, bc):
     import numpy.random
@@ -415,10 +426,10 @@ def _test_adjoint_constant_boundary(J, bc):
     h = Constant(1)
     c = Constant(1)
 
-    eps_ = [0.4/2.0**i for i in range(4)]
+    eps_ = [0.4 / 2.0**i for i in range(4)]
     residuals = []
     for eps in eps_:
-        bc.set_value(Constant(c + eps*h))
+        bc.set_value(Constant(c + eps * h))
         Jp = J(bc)
         tape.clear_tape()
         bc.set_value(c)
@@ -428,15 +439,14 @@ def _test_adjoint_constant_boundary(J, bc):
 
         dJdbc = bc.adj_value[0]
 
-        residual = abs(Jp - Jm - eps*dJdbc.sum())
+        residual = abs(Jp - Jm - eps * dJdbc.sum())
         residuals.append(residual)
 
     r = convergence_rates(residuals, eps_)
     print(r)
 
     tol = 1E-1
-    assert( r[-1] > 2-tol )
-
+    assert(r[-1] > 2 - tol)
 
 
 def _test_adjoint_constant(J, c):
@@ -446,11 +456,11 @@ def _test_adjoint_constant(J, c):
 
     h = Constant(1)
 
-    eps_ = [0.01/2.0**i for i in range(4)]
+    eps_ = [0.01 / 2.0**i for i in range(4)]
     residuals = []
     for eps in eps_:
 
-        Jp = J(c + eps*h)
+        Jp = J(c + eps * h)
         tape.clear_tape()
         Jm = J(c)
         Jm.adj_value = 1.0
@@ -459,14 +469,15 @@ def _test_adjoint_constant(J, c):
         dJdc = c.adj_value[0]
         print(dJdc)
 
-        residual = abs(Jp - Jm - eps*dJdc)
+        residual = abs(Jp - Jm - eps * dJdc)
         residuals.append(residual)
 
     r = convergence_rates(residuals, eps_)
     print(r)
 
     tol = 1E-1
-    assert( r[-1] > 2-tol )
+    assert(r[-1] > 2 - tol)
+
 
 def _test_adjoint(J, f):
     import numpy.random
@@ -477,11 +488,11 @@ def _test_adjoint(J, f):
     h = Function(V)
     h.vector()[:] = numpy.random.rand(V.dim())
 
-    eps_ = [0.01/2.0**i for i in range(5)]
+    eps_ = [0.01 / 2.0**i for i in range(5)]
     residuals = []
     for eps in eps_:
 
-        Jp = J(f + eps*h)
+        Jp = J(f + eps * h)
         tape.clear_tape()
         Jm = J(f)
         Jm.adj_value = 1.0
@@ -489,7 +500,7 @@ def _test_adjoint(J, f):
 
         dJdf = f.adj_value
 
-        residual = abs(Jp - Jm - eps*dJdf.inner(h.vector()))
+        residual = abs(Jp - Jm - eps * dJdf.inner(h.vector()))
         residuals.append(residual)
 
     r = convergence_rates(residuals, eps_)
@@ -497,4 +508,56 @@ def _test_adjoint(J, f):
     print(residuals)
 
     tol = 1E-1
-    assert( r[-1] > 2-tol )
+    assert(r[-1] > 2 - tol)
+
+
+class top_half(SubDomain):
+    def inside(self, x, on_boundary):
+        return x[1] > 0.5
+
+
+class top_boundary(SubDomain):
+    def inside(self, x, on_boundary):
+        return abs(1 - x[1]) < 1e-10
+
+
+def test_solver_ident_zeros():
+    """
+    Test using ident zeros to restrict half of the domain
+    """
+    from fenics_adjoint import (UnitSquareMesh, Function, assemble, solve, project,
+                                Expression, DirichletBC)
+    mesh = UnitSquareMesh(10, 10)
+    cf = MeshFunction("size_t", mesh, mesh.topology().dim(), 0)
+    top_half().mark(cf, 1)
+
+    ff = MeshFunction("size_t", mesh, mesh.topology().dim() - 1, 0)
+    top_boundary().mark(ff, 1)
+
+    dx = Measure("dx", domain=mesh, subdomain_data=cf)
+
+    V = FunctionSpace(mesh, "CG", 1)
+    u, v = TrialFunction(V), TestFunction(V)
+    a = inner(grad(u), grad(v)) * dx(1)
+    w = Function(V)
+
+    with stop_annotating():
+        w.assign(project(Expression("x[0]", degree=1), V))
+    rhs = w**3 * v * dx(1)
+    A = assemble(a, keep_diagonal=True)
+    A.ident_zeros()
+    b = assemble(rhs)
+    bc = DirichletBC(V, Constant(1), ff, 1)
+    bc.apply(A, b)
+    uh = Function(V)
+    solve(A, uh.vector(), b, "umfpack")
+
+    J = assemble(inner(uh, uh) * dx(1))
+
+    Jhat = ReducedFunctional(J, Control(w))
+    with stop_annotating():
+        w1 = project(Expression("x[0]*x[1]", degree=2), V)
+    results = taylor_to_dict(Jhat, w, w1)
+    assert(min(results["R0"]["Rate"]) > 0.95)
+    assert(min(results["R1"]["Rate"]) > 1.95)
+    assert(min(results["R2"]["Rate"]) > 2.95)

--- a/tests/fenics_adjoint/test_solving.py
+++ b/tests/fenics_adjoint/test_solving.py
@@ -1,9 +1,9 @@
-from fenics_adjoint import *
-from fenics import *
-
 import pytest
 pytest.importorskip("fenics")
 
+
+from fenics import *
+from fenics_adjoint import *
 
 def test_linear_problem():
     mesh = IntervalMesh(10, 0, 1)


### PR DESCRIPTION
Related to [this discourse query](https://fenicsproject.discourse.group/t/large-mesh-error-petsc-error-76-adjoint-calculation/422/21) I discovered that most solvers do not use ident_zeros and keep_diagonal traverse through the adjoint and tlm computations.
This has been added.


Modified structure interaction example that uses the keep_diagonal and ident_zeros methods:
```
from fenics import *
from fenics_adjoint import *
# classes for sub domains
class Fluid(SubDomain):
    def inside(self, x, on_boundary):
        return x[1] >= 0.0

class Solid(SubDomain):
    def inside(self, x, on_boundary):
        return x[1] <= 0.0

# classes for boundaries
class Top(SubDomain):
    def inside(self, x, on_boundary):
        return near(x[1], 0.1)

class LeftF(SubDomain):
    def inside(self, x, on_boundary):
        return near(x[0], 0.0) and between(x[1], (0.0, 0.1))

class RightF(SubDomain):
    def inside(self, x, on_boundary):
        return near(x[0], 1.0) and between(x[1], (0.0, 0.1))

class Interface(SubDomain):
    def inside(self, x, on_boundary):
        return near(x[1], 0.0)

class LeftS(SubDomain):
    def inside(self, x, on_boundary):
        return near(x[0], 0.0) and between(x[1], (-0.1, 0.0))

class RightS(SubDomain):
    def inside(self, x, on_boundary):
        return near(x[0], 1.0) and between(x[1], (-0.1, 0.0))

class Bottom(SubDomain):
    def inside(self, x, on_boundary):
        return near(x[1], -0.1)

# Fluid parameters for the variational problem
muF  = Constant(1.002, name="muF")
rhoF = Constant(998, name="rhoF")
cdF  = Constant(0.5984, name="cdF") #0.5984
cpF  = Constant(4181, name="cpF")
alpF = Constant(cdF/rhoF/cpF, name="alpF")

# Solid parameters for the variational problem
muS  = Constant(1, name="muS")
rhoS = Constant(2705, name="rhoS")
cdS  = Constant(227, name="cdS") #227
cpS  = Constant(900, name="cpS")
alpS = Constant(cdS/rhoS/cpS, name="alpS")

mesh = RectangleMesh(Point(0.0, -0.1), Point(1.0, 0.1), 250, 50)

# Define markers for Subdomians, Dirichlet and Neuman bcs
subdomain_marker = MeshFunction("size_t", mesh, mesh.geometry().dim(), 0)
Fluid().mark(subdomain_marker, 1)
Solid().mark(subdomain_marker, 2)

boundary_marker = MeshFunction("size_t", mesh, mesh.geometry().dim()-1, 0)
Top().mark(boundary_marker, 1)
LeftF().mark(boundary_marker, 2)
RightF().mark(boundary_marker, 3)
Interface().mark(boundary_marker, 4) # interface
LeftS().mark(boundary_marker, 5)
RightS().mark(boundary_marker, 6)
Bottom().mark(boundary_marker, 7)

# Define mesh perturbation field
S = VectorFunctionSpace(mesh, "CG", 1)
s = Function(S, name="Mesh perturbation field")
ALE.move(mesh, s)

# Solving fluid problem
# Define Function spaces
V  = VectorElement("CG", triangle, 2)       # Velocity on the fluid domain
P  = FiniteElement("CG", triangle, 1)       # Pressure on the fluid domain
element = MixedElement([V, P])
W = FunctionSpace(mesh, element)

# Define boundary conditions for fluid problem
U_noslip = Constant((0.0,0.0), name="U_noslip")
pressure_left = Constant(15.0, name="pressure_left")
pressure_right = Constant(0.0, name="pressure_right")
bc1 = DirichletBC(W.sub(0), U_noslip, boundary_marker, 1)
bc2 = DirichletBC(W.sub(0), U_noslip, boundary_marker, 4)
bcs = [bc1,bc2]

# define trial functions and test functions
(u, p) = TrialFunctions(W)
(v, q) = TestFunctions(W)

# define the domains for integration
dx = Measure("dx", domain=mesh, subdomain_data=subdomain_marker)
ds = Measure("ds", domain=mesh, subdomain_data=boundary_marker)

# unit normal vector on the surfaces of the fluid mesh
n = FacetNormal(mesh)

# Linear solver
# weak form for Stroke flow
a = muF*inner(grad(u), grad(v))*dx(1) \
    - p*div(v)*dx(1) \
    + q*div(u)*dx(1)

l = - pressure_left*inner(n, v)*ds(2)\
    - pressure_right*inner(n, v)*ds(3)

# Assemble the LHS and RHS
A = assemble(a, keep_diagonal=True)
L = assemble(l)

# Apply boundary conditions
[bc.apply(A) for bc in bcs]
[bc.apply(L) for bc in bcs]

# solve for the solution
A.ident_zeros()
w = Function(W, name="fluid variables")
#solve(A, w.vector(), L, "mumps")
solver_stokes = LUSolver(A, method="mumps")
solver_stokes.solve(w.vector(), L)

# Save the solutions for the fluid problem
(u, p) = w.split()

# Solve the heat transfer problem
# Define Function spaces
T  = FiniteElement("CG", triangle, 3)
WT = FunctionSpace(mesh, T)
# Define the boundary conditions for the heat transfer problem
Ti = Constant(300.0, name="T_in")
Tb = Constant(310.0, name="T_bottom")
bc4 = DirichletBC(WT, Ti, boundary_marker, 2)
bc5 = DirichletBC(WT, Tb, boundary_marker, 7)
bcT = [bc4, bc5]

# Define trial and test functions
t = TrialFunction(WT)
z = TestFunction(WT)

# define functions (unknowns in the weak form)
t = Function(WT, name="temperature")

# weak form for the thermal problem
T = cdS*inner(grad(t), grad(z))*dx(2) \
    + cdF*inner(grad(t), grad(z))*dx(1) \
    + rhoF*cpF*inner(dot(u,grad(t)),z)*dx(1)\

# Determine the Jacobian
JT = derivative(T, t)

# solve the nonlinear problem
problem = NonlinearVariationalProblem(T, t, bcT, J=JT)
solver = NonlinearVariationalSolver(problem)
prm = solver.parameters
prm['newton_solver']['absolute_tolerance'] = 1e-7
prm['newton_solver']['relative_tolerance'] = 4.90E-15
prm['newton_solver']['maximum_iterations'] = 100
prm['newton_solver']['relaxation_parameter'] = 1.0
prm["newton_solver"]["linear_solver"] = "mumps"
solver.solve()

# Set the objective function
JThermal = assemble(t*dx)

# Calculate the sensitivity
JhatT = ReducedFunctional(JThermal, Control(s))

dJdsT = JhatT.derivative()
x = SpatialCoordinate(mesh)
s1 = project(as_vector((0,x[0]*(x[1]-0.1)*(x[1]+0.1))), S)
bcs = []
for marker in [1,2,3,5,6,7]:
    bcs.append(DirichletBC(S, Constant((0,0)), boundary_marker, marker))
for bc in bcs:
    bc.apply(s1.vector())

print(taylor_to_dict(JhatT, s, s1))
```