### PR TITLE
Adding missing ident_zeros for solve(A,u.vector(), b)

### DIFF
--- a/fenics_adjoint/blocks/solving.py
+++ b/fenics_adjoint/blocks/solving.py
@@ -33,7 +33,8 @@ class SolveLinearSystemBlock(GenericSolveBlock):
             kwargs = self.assemble_kwargs.copy()
             kwargs["bcs"] = bcs
             A = self.compat.assemble_adjoint_value(dFdu_adj_form, **kwargs)
-
+        if self.ident_zeros_tol is not None:
+            A.ident_zeros(self.ident_zeros_tol)
         [bc.apply(dJdu) for bc in bcs]
 
         adj_sol = self.compat.create_function(self.function_space)


### PR DESCRIPTION
First reported at https://fenicsproject.discourse.group/t/large-mesh-error-petsc-error-76-adjoint-calculation/422/28?u=dokken