### PR TITLE
tape: fixed tensorflow 2.0 incompatibility in visualise()

### DIFF
--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -343,8 +343,8 @@ class Tape(object):
         self._tf_add_blocks()
 
         # Write graph to file
-        with tf.Session() as sess:
-            writer = tf.summary.FileWriter(output, sess.graph)
+        with tf.compat.v1.Session() as sess:
+            writer = tf.compat.v1.summary.FileWriter(output, sess.graph)
             writer.close()
 
         if not launch_tensorboard or not open_in_browser:


### PR DESCRIPTION
Currently, `Tape.visualise()` does not work with TensorFlow 2.0 because TensorFlow 2.0 does not contain the `tf.Session` and `tf.summary.fileWriter` classes --- those are instead contained in `tf.compat.v1`. I've fixed this, so that `Tape.visualise()` works with TensorFlow 2.0 now.