### PR TITLE
project: add support for function kwarg

### DIFF
--- a/fenics_adjoint/blocks/projection.py
+++ b/fenics_adjoint/blocks/projection.py
@@ -12,4 +12,8 @@ class ProjectBlock(SolveVarFormBlock):
         a = self.backend.inner(w, Pv) * dx
         L = self.backend.inner(w, v) * dx
 
+        # Pop "function" kwarg if present.
+        # This relies on the return value of project == function if given.
+        kwargs.pop("function", None)
+
         super(ProjectBlock, self).__init__(a == L, output, bcs, *args, **kwargs)

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -132,7 +132,7 @@ class OverloadedType(object):
             OverloadedType: An instance of the same type as `self`.
 
         """
-        raise NotImplementedError
+        raise NotImplementedError(f"OverloadedType._ad_convert_type not defined for class {type(self)}.")
 
     def _ad_create_checkpoint(self):
         """This method must be overridden.

--- a/tests/fenics_adjoint/test_projection.py
+++ b/tests/fenics_adjoint/test_projection.py
@@ -85,3 +85,23 @@ def test_multiple_meshes():
     assert min(results["R0"]["Rate"]) > 0.9
     assert min(results["R1"]["Rate"]) > 1.9
     assert min(results["R2"]["Rate"]) > 2.9
+
+
+def test_implicit_output():
+    mesh = UnitSquareMesh(5, 5)
+    V = FunctionSpace(mesh, "CG", 1)
+
+    t = Constant(2.0)
+    y_expr = exp(-t)
+    y = Function(V)
+    project(y_expr, V, function=y)
+
+    J = assemble(y**4*dx)
+    Jhat = ReducedFunctional(J, Control(t))
+
+    h = Constant(1)
+    results = taylor_to_dict(Jhat, t, h)
+
+    assert min(results["R0"]["Rate"]) > 0.9
+    assert min(results["R1"]["Rate"]) > 1.9
+    assert min(results["R2"]["Rate"]) > 2.9


### PR DESCRIPTION
The keyword argument is ignored, but now no longer sent to the solver interface during recomputation.