### PR TITLE
optimization: add None support for scipy bounds

### DIFF
--- a/pyadjoint/optimization/optimization.py
+++ b/pyadjoint/optimization/optimization.py
@@ -21,9 +21,9 @@ def serialise_bounds(rf_np, bounds):
     for i in range(2):
         for j in range(len(bounds[i])):
             bound = bounds[i][j]
-            if type(bound) in [int, float, np.int32, np.int64, np.float32, np.float64]:
+            if bound is None or isinstance(bound, (int, float)):
                 bound_len = len(rf_np.get_global(rf_np.controls[j]))
-                const_bound = bound * np.ones(bound_len)
+                const_bound = np.array([bound] * bound_len)
 
                 bounds_arr[i] += const_bound.tolist()
             else:


### PR DESCRIPTION
Allows the use of bounds on some but not all controls with scipy.
Or specifying only a lower or upper bound.