### PR TITLE
Handle checkpoint correctly in minimize()

### DIFF
--- a/pyadjoint/adjfloat.py
+++ b/pyadjoint/adjfloat.py
@@ -115,7 +115,7 @@ class AdjFloat(OverloadedType, float):
 
     @staticmethod
     def _ad_assign_numpy(dst, src, offset):
-        dst = float(src[offset:offset + 1])
+        dst = type(dst)(src[offset:offset + 1])
         offset += 1
         return dst, offset
 

--- a/pyadjoint/optimization/optimization.py
+++ b/pyadjoint/optimization/optimization.py
@@ -59,7 +59,7 @@ def minimize_scipy_generic(rf_np, method, bounds=None, **kwargs):
 
     project = kwargs.pop("project", False)
 
-    m = [p._ad_restore_at_checkpoint(p.data()) for p in rf_np.controls]
+    m = [p.tape_value() for p in rf_np.controls]
     m_global = rf_np.obj_to_array(m)
     J = rf_np.__call__
 
@@ -134,8 +134,7 @@ def minimize_scipy_generic(rf_np, method, bounds=None, **kwargs):
     else:
         res = scipy_minimize(J, m_global, method=method, **kwargs)
 
-    rf_np.set_controls(np.array(res["x"]))
-    m = [p.data() for p in rf_np.controls]
+    m = rf_np.set_controls(np.array(res["x"]))
     return m
 
 
@@ -151,7 +150,7 @@ def minimize_custom(rf_np, bounds=None, **kwargs):
             'the "algorithm" parameter. Make sure that this function accepts the same arguments as '
             'scipy.optimize.minimize.')
 
-    m = [p.data() for p in rf_np.controls]
+    m = [p.tape_value() for p in rf_np.controls]
     m_global = rf_np.obj_to_array(m)
     J = rf_np.__call__
 
@@ -164,13 +163,12 @@ def minimize_custom(rf_np, bounds=None, **kwargs):
     res = algo(J, m_global, dJ, H, bounds, **kwargs)
 
     try:
-        rf_np.set_controls(np.array(res))
+        m = rf_np.set_controls(np.array(res))
     except Exception as e:
         # TODO: Is this possible?
         raise e(
             "Failed to update the optimised control values. "
             "Are you sure your custom optimisation algorithm returns an array containing the optimised values?")
-    m = [p.data() for p in rf_np.controls]
     return m
 
 

--- a/pyadjoint/optimization/optimization.py
+++ b/pyadjoint/optimization/optimization.py
@@ -59,7 +59,7 @@ def minimize_scipy_generic(rf_np, method, bounds=None, **kwargs):
 
     project = kwargs.pop("project", False)
 
-    m = [p.data() for p in rf_np.controls]
+    m = [p._ad_restore_at_checkpoint(p.data()) for p in rf_np.controls]
     m_global = rf_np.obj_to_array(m)
     J = rf_np.__call__
 

--- a/pyadjoint/optimization/optimization_problem.py
+++ b/pyadjoint/optimization/optimization_problem.py
@@ -49,7 +49,7 @@ class OptimizationProblem(object):
                     raise TypeError("Each bound should be a tuple of length 2 (lb, ub)")
 
                 for b in bound:
-                    klass = control.data().__class__
+                    klass = control.tape_value().__class__
                     if not (isinstance(b, (int, float, type(None), klass))):
                         raise TypeError("This pair (lb, ub) should be None, a float, or a %s." % klass)
 

--- a/pyadjoint/optimization/optimization_problem.py
+++ b/pyadjoint/optimization/optimization_problem.py
@@ -1,7 +1,7 @@
 import collections
 
 from .constraints import Constraint, canonicalise
-from ..overloaded_type import OverloadedType
+from ..overloaded_type import OverloadedType, create_overloaded_object
 from ..reduced_functional import ReducedFunctional
 
 __all__ = ['MinimizationProblem', 'MaximizationProblem']
@@ -49,6 +49,7 @@ class OptimizationProblem(object):
                     raise TypeError("Each bound should be a tuple of length 2 (lb, ub)")
 
                 for b in bound:
+                    b = create_overloaded_object(b, suppress_warning=True)
                     klass = control.tape_value().__class__
                     if not (isinstance(b, (int, float, type(None), klass))):
                         raise TypeError("This pair (lb, ub) should be None, a float, or a %s." % klass)

--- a/pyadjoint/optimization/rol_solver.py
+++ b/pyadjoint/optimization/rol_solver.py
@@ -123,7 +123,7 @@ try:
 
             OptimizationSolver.__init__(self, problem, parameters)
             self.rolobjective = ROLObjective(problem.reduced_functional)
-            x = [p.data() for p in self.problem.reduced_functional.controls]
+            x = [p.tape_value() for p in self.problem.reduced_functional.controls]
             self.rolvector = ROLVector(x, inner_product=inner_product)
             self.params_dict = parameters
 

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -55,7 +55,7 @@ class ReducedFunctional(object):
 
         """
         # Call callback
-        values = [c.data() for c in self.controls]
+        values = [c.tape_value() for c in self.controls]
         self.derivative_cb_pre(self.controls.delist(values))
 
         derivatives = compute_gradient(self.functional,
@@ -90,7 +90,7 @@ class ReducedFunctional(object):
                 Should be an instance of the same type as the control.
         """
         # Call callback
-        values = [c.data() for c in self.controls]
+        values = [c.tape_value() for c in self.controls]
         self.hessian_cb_pre(self.controls.delist(values))
 
         r = compute_hessian(self.functional, self.controls, m_dot, options=options, tape=self.tape)

--- a/pyadjoint/reduced_functional_numpy.py
+++ b/pyadjoint/reduced_functional_numpy.py
@@ -104,11 +104,11 @@ class ReducedFunctionalNumPy(ReducedFunctional):
         return self.get_global(obj)
 
     def get_controls(self):
-        m = [p.data() for p in self.controls]
+        m = [p.tape_value() for p in self.controls]
         return self.obj_to_array(m)
 
     def set_controls(self, array):
-        m = [p.data() for p in self.controls]
+        m = [p.tape_value() for p in self.controls]
         return self.set_local(m, array)
 
 

--- a/pyadjoint/reduced_functional_numpy.py
+++ b/pyadjoint/reduced_functional_numpy.py
@@ -110,7 +110,7 @@ class ReducedFunctionalNumPy(ReducedFunctional):
     def set_controls(self, array):
         m = [p.tape_value() for p in self.controls]
         m = self.set_local(m, array)
-        for control,m_i in zip(self.controls, m):
+        for control, m_i in zip(self.controls, m):
             control.update(m_i)
         return m
 

--- a/pyadjoint/reduced_functional_numpy.py
+++ b/pyadjoint/reduced_functional_numpy.py
@@ -109,7 +109,10 @@ class ReducedFunctionalNumPy(ReducedFunctional):
 
     def set_controls(self, array):
         m = [p.tape_value() for p in self.controls]
-        return self.set_local(m, array)
+        m = self.set_local(m, array)
+        for control,m_i in zip(self.controls, m):
+            control.update(m_i)
+        return m
 
 
 def set_local(coeffs, m_array):

--- a/tests/fenics_adjoint/test_optimization_scipy.py
+++ b/tests/fenics_adjoint/test_optimization_scipy.py
@@ -4,7 +4,7 @@ pytest.importorskip("fenics")
 from fenics import *
 from fenics_adjoint import *
 
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_approx_equal
 
 
 def test_maximize():
@@ -16,3 +16,15 @@ def test_maximize():
     Jhat = ReducedFunctional(J, Control(f))
     opt = maximize(Jhat)
     assert_allclose(opt.vector().get_local(), pi, rtol=1e-2)
+
+def test_adjfloat_minimize():
+    x = AdjFloat(5)
+    J = (x - 1)**2
+    Jhat = ReducedFunctional(J, Control(x))
+
+    # Test with a callback that modifies the tape values. This used to cause problems with an immutable Control.
+    def callback(xk):
+        new_J = Jhat(AdjFloat(2))
+
+    opt = minimize(Jhat, callback=callback)
+    assert_approx_equal(opt, 1)

--- a/tests/fenics_adjoint/test_reduced_functional.py
+++ b/tests/fenics_adjoint/test_reduced_functional.py
@@ -159,7 +159,7 @@ def test_time_dependent():
     
     h = Function(V)
     h.vector()[:] = rand(V.dim())
-    assert(taylor_test(Jhat, control.data(), h) > 1.9)
+    assert(taylor_test(Jhat, control.tape_value(), h) > 1.9)
 
 def test_burgers():
     n = 30

--- a/tests/fenics_adjoint/test_tlm.py
+++ b/tests/fenics_adjoint/test_tlm.py
@@ -154,7 +154,7 @@ def test_time_dependent(solve_type):
     h.vector()[:] = rand(V.dim())
     u_1.tlm_value = h
     tape.evaluate_tlm()
-    assert (taylor_test(Jhat, control.data(), h, dJdm=J.block_variable.tlm_value) > 1.9)
+    assert (taylor_test(Jhat, control.tape_value(), h, dJdm=J.block_variable.tlm_value) > 1.9)
 
 
 def test_burgers():

--- a/tests/firedrake_adjoint/test_reduced_functional.py
+++ b/tests/firedrake_adjoint/test_reduced_functional.py
@@ -130,7 +130,7 @@ def test_time_dependent():
     
     h = Function(V)
     h.vector()[:] = 1
-    assert taylor_test(Jhat, control.data(), h) > 1.9
+    assert taylor_test(Jhat, control.tape_value(), h) > 1.9
 
 
 def test_mixed_boundary():

--- a/tests/firedrake_adjoint/test_tlm.py
+++ b/tests/firedrake_adjoint/test_tlm.py
@@ -149,7 +149,7 @@ def test_time_dependent(solve_type):
     h.vector()[:] = rand(h.dof_dset.size)
     u_1.tlm_value = h
     tape.evaluate_tlm()
-    assert (taylor_test(Jhat, control.data(), h, dJdm=J.block_variable.tlm_value) > 1.9)
+    assert (taylor_test(Jhat, control.tape_value(), h, dJdm=J.block_variable.tlm_value) > 1.9)
 
 
 def test_burgers():

--- a/tests/migration/ode_solver/ode_solver.py
+++ b/tests/migration/ode_solver/ode_solver.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     dtm = TimeMeasure()
     J = Functional(inner(u, u)*dx*dtm[FINISH_TIME])
     m = Control(u)
-    assert m.data().vector()[0] == u0.vector()[0]
+    assert m.tape_value().vector()[0] == u0.vector()[0]
     Jm = assemble(inner(u, u)*dx)
 
     def Jhat(ic):

--- a/tests/migration/ode_vector/ode_vector.py
+++ b/tests/migration/ode_vector/ode_vector.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     dtm = TimeMeasure()
     J = Functional(inner(u[1], u[1])*dx*dtm[FINISH_TIME])
     m = Control(u)
-    assert m.data().vector()[0] == u0.vector()[0]
+    assert m.tape_value().vector()[0] == u0.vector()[0]
     Jm = assemble(inner(u[1], u[1])*dx)
 
     def Jhat(ic):

--- a/tests/migration/optimal_control_mms/optimal_control_mms.py
+++ b/tests/migration/optimal_control_mms/optimal_control_mms.py
@@ -50,14 +50,14 @@ def solve_optimal_control(n):
     rf = ReducedFunctional(J, control)
 
     minimize(rf, method = "Newton-CG", tol = 1e-16, options = {'disp': True})
-    solve_pde(u, V, control.data())
+    solve_pde(u, V, control.tape_value())
 
     # Define the analytical expressions
     m_analytic = Expression("sin(pi*x[0])*sin(pi*x[1])", degree=4)
     u_analytic = Expression("1/(2*pi*pi)*sin(pi*x[0])*sin(pi*x[1])", degree=4)
 
     # Compute the error
-    control_error = errornorm(m_analytic, control.data())
+    control_error = errornorm(m_analytic, control.tape_value())
     state_error = errornorm(u_analytic, u)
     return control_error, state_error
 

--- a/tests/migration/optimization_optizelle_algebra/optimization_optizelle_algebra.py
+++ b/tests/migration/optimization_optizelle_algebra/optimization_optizelle_algebra.py
@@ -82,9 +82,9 @@ class VolumeConstraint(EqualityConstraint):
 
 # Instantiate and rescale the bound constraints manually,
 # so that the finite difference test reaches the region of convergence
-lower_bound = OptizelleBoundConstraint(m.data(), 0., 'lower')
+lower_bound = OptizelleBoundConstraint(m.tape_value(), 0., 'lower')
 lower_bound.scale *= 1000.
-upper_bound = OptizelleBoundConstraint(m.data(), 1., 'upper')
+upper_bound = OptizelleBoundConstraint(m.tape_value(), 1., 'upper')
 upper_bound.scale *= 1000.
 
 problem = MinimizationProblem(Jhat,

--- a/tests/migration/rush_larsen/rush_larsen.py
+++ b/tests/migration/rush_larsen/rush_larsen.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         dtm = TimeMeasure()
         J = Functional(inner(u, u)*dx*dtm[FINISH_TIME])
         m = Control(u)
-        assert m.data().vector()[0] == u0.vector()[0]
+        assert m.tape_value().vector()[0] == u0.vector()[0]
         Jm = assemble(inner(u, u)*dx)
 
         def Jhat(ic):


### PR DESCRIPTION
There's a bug in `minimize_scipy_generic()` where it calls `ReducedFunctionalNumPy.obj_to_array()` on the output of `Control.data()`. 

```python
m = [p.data() for p in rf_np.controls]
m_global = rf_np.obj_to_array(m)
```

This is an issue because `.data()` returns the block_variable's checkpoint, which is not necessarily an OverloadedType, so to actually use it in `.obj_to_array()`, the checkpoint needs to be restored first.

I fixed this by calling `._ad_restore_at_checkpoint()`.

```python
m = [p._ad_restore_at_checkpoint(p.data()) for p in rf_np.controls]
```

Right now, this can't be tested easily, since all the OverloadedType implementations use their own type for the checkpoint. Let me know if there's a good way to test this that I should add. 