### PR TITLE
Minor tweaks for AdjFloat

### DIFF
--- a/pyadjoint/adjfloat.py
+++ b/pyadjoint/adjfloat.py
@@ -92,7 +92,10 @@ class AdjFloat(OverloadedType, float):
         return PowBlock(self, power)
 
     def _ad_convert_type(self, value, options={}):
-        return AdjFloat(value)
+        try:
+            return AdjFloat(value)
+        except Exception:
+            return AdjFloat(value.dat.data[0])
 
     def _ad_create_checkpoint(self):
         # Floats are immutable.

--- a/tests/pyadjoint/test_overload_function.py
+++ b/tests/pyadjoint/test_overload_function.py
@@ -42,7 +42,7 @@ def ad_sin(y):
 
 @overloaded_function(CosBlock)
 def cos(x):
-    return AdjFloat(np.sin(x))
+    return AdjFloat(np.cos(x))
 
 
 def test_overload_function():


### PR DESCRIPTION
Two minor tweaks:
* use `cos` in the overloaded function for `CosBlock`, rather than `sin`;
* allow conversion from `AdjFloat` to `Constant`.

Maybe there is a nicer way to do the second point, but I didn't want to have to import the backend to check `isinstance(value, Constant)`.