### PR TITLE
Remove xfail fixed by Firedrake PR2055

### DIFF
--- a/tests/firedrake_adjoint/test_reduced_functional.py
+++ b/tests/firedrake_adjoint/test_reduced_functional.py
@@ -163,7 +163,6 @@ def test_mixed_boundary():
     assert taylor_test(Jhat, f, h) > 1.9
 
 
-@pytest.mark.xfail(reason="Constant annotation not yet quite right")
 def test_assemble_recompute():
     mesh = UnitSquareMesh(10, 10)
     V = FunctionSpace(mesh, "CG", 1)


### PR DESCRIPTION
`tests/firedrake_adjoint/test_reduced_functional.py::test_assemble_recompute` now passes with the changes due to Firedrake [PR 2055](https://github.com/firedrakeproject/firedrake/pull/2055).