### PR TITLE
Fix deprecation warnings in cyipopt

### DIFF
--- a/pyadjoint/optimization/ipopt_solver.py
+++ b/pyadjoint/optimization/ipopt_solver.py
@@ -44,7 +44,7 @@ class IPOPTSolver(OptimizationSolver):
         # A callback that evaluates the functional and derivative.
         J = self.rfn.__call__
         dJ = partial(self.rfn.derivative, forget=False)
-        nlp = cyipopt.problem(
+        nlp = cyipopt.Problem(
             n=len(ub),  # length of control vector
             lb=lb,  # lower bounds on control vector
             ub=ub,  # upper bounds on control vector
@@ -67,12 +67,12 @@ class IPOPTSolver(OptimizationSolver):
         """
         # TODO: Earlier the commented out code above was present.
         # Figure out how to solve parallel output cases like these in pyadjoint.
-        nlp.addOption("print_level", 6)
+        nlp.add_option("print_level", 6)
 
         if isinstance(self.problem, MaximizationProblem):
             # multiply objective function by -1 internally in
             # ipopt to maximise instead of minimise
-            nlp.addOption('obj_scaling_factor', -1.0)
+            nlp.add_option('obj_scaling_factor', -1.0)
 
         self.ipopt_problem = nlp
 
@@ -191,7 +191,7 @@ class IPOPTSolver(OptimizationSolver):
             for param, value in self.parameters.items():
                 # some parameters have a different name in ipopt
                 param = self._param_map.get(param, param)
-                self.ipopt_problem.addOption(param, value)
+                self.ipopt_problem.add_option(param, value)
 
     def solve(self):
         """Solve the optimization problem and return the optimized controls."""


### PR DESCRIPTION
When running dolfin-adjoint with IPOPSolver I get the following warnings from `cyipopt` (version 1.1.0)

```
2021-12-15 21:15:06,568 [96654] WARNING  py.warnings: /Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/pyadjoint/optimization/ipopt_solver.py:47: FutureWarning: The class named 'problem' will soon be deprecated in CyIpopt. Please replace all uses and use 'Problem' going forward.
  nlp = cyipopt.problem(

2021-12-15 21:15:06,569 [96654] INFO     cyipopt: b'Hessian callback not given, setting nele_hess to 0'
2021-12-15 21:15:06,576 [96654] INFO     cyipopt: b'Hessian callback not given, using approximation'
2021-12-15 21:15:06,577 [96654] WARNING  py.warnings: /Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/cyipopt/utils.py:43: FutureWarning: The method named 'addOption' in class 'Problem' will soon be deprecated in CyIpopt. Please replace all uses and use 'add_option' going forward.
  warnings.warn(msg, FutureWarning)
```
This PR fixes these deprecation warnings