### PR TITLE
docs: overloading: remove in-place operation for normalise

### DIFF
--- a/docs/source/_static/overloading/normalise.py
+++ b/docs/source/_static/overloading/normalise.py
@@ -4,5 +4,5 @@ from fenics_adjoint import *
 
 def normalise(func):
     vec = func.vector()
-    vec /= vec.norm('l2')
-    return Function(func.function_space(), vec)
+    normalised_vec = vec / vec.norm('l2')
+    return Function(func.function_space(), normalised_vec)


### PR DESCRIPTION
As suggested by @mulbrich in #73.