### PR TITLE
Fix Taylor test in stokes problem example

### DIFF
--- a/examples/stokes-shape-opt/stokes_problem.py
+++ b/examples/stokes-shape-opt/stokes_problem.py
@@ -95,6 +95,7 @@ from dolfin import *
 from dolfin_adjoint import *
 set_log_level(LogLevel.ERROR)
 
+parameters["form_compiler"]["quadrature_degree"] = 4
 # Next, we load the facet marker values used in the mesh, as well as some
 # geometrical quantities mesh-generator file.
 


### PR DESCRIPTION
If I run the stokes problem example, I get the following error
```
$ python stokes_problem.py    
RUNNING THE L-BFGS-B CODE

           * * *

Machine precision = 2.220D-16
 N =          360     M =           10
 This problem is unconstrained.

At X0         0 variables are exactly at the bounds

At iterate    0    f=  2.42940D+01    |proj g|=  1.45808D-03

At iterate    1    f=  2.35673D+01    |proj g|=  1.33224D-03

At iterate    2    f=  2.08100D+01    |proj g|=  8.12932D-04

At iterate    3    f=  2.07031D+01    |proj g|=  4.41014D-04

At iterate    4    f=  2.06888D+01    |proj g|=  1.81867D-04

At iterate    5    f=  2.06832D+01    |proj g|=  1.63188D-04

At iterate    6    f=  2.06776D+01    |proj g|=  2.13642D-04

At iterate    7    f=  2.06547D+01    |proj g|=  3.45200D-04

At iterate    8    f=  2.06261D+01    |proj g|=  4.32674D-04

At iterate    9    f=  2.05871D+01    |proj g|=  3.53824D-04

At iterate   10    f=  2.05443D+01    |proj g|=  5.66498D-05

At iterate   11    f=  2.05439D+01    |proj g|=  2.78659D-05

At iterate   12    f=  2.05437D+01    |proj g|=  2.72891D-05

At iterate   13    f=  2.05428D+01    |proj g|=  6.95773D-05

At iterate   14    f=  2.05415D+01    |proj g|=  9.76406D-05

At iterate   15    f=  2.05393D+01    |proj g|=  9.94146D-05

At iterate   16    f=  2.05389D+01    |proj g|=  9.94442D-05

At iterate   17    f=  2.05375D+01    |proj g|=  5.84419D-05

At iterate   18    f=  2.05369D+01    |proj g|=  2.38692D-05

At iterate   19    f=  2.05365D+01    |proj g|=  3.41734D-05

At iterate   20    f=  2.05362D+01    |proj g|=  3.80532D-05

At iterate   21    f=  2.05362D+01    |proj g|=  7.41560D-05

At iterate   22    f=  2.05357D+01    |proj g|=  2.01040D-05

At iterate   23    f=  2.05357D+01    |proj g|=  1.33088D-05

At iterate   24    f=  2.05356D+01    |proj g|=  1.86870D-05

At iterate   25    f=  2.05355D+01    |proj g|=  2.77669D-05

At iterate   26    f=  2.05352D+01    |proj g|=  3.82563D-05

At iterate   27    f=  2.05348D+01    |proj g|=  3.10041D-05

At iterate   28    f=  2.05348D+01    |proj g|=  3.43028D-05

At iterate   29    f=  2.05346D+01    |proj g|=  1.45780D-05

At iterate   30    f=  2.05346D+01    |proj g|=  1.01941D-05

At iterate   31    f=  2.05346D+01    |proj g|=  1.08477D-05

           * * *

Tit   = total number of iterations
Tnf   = total number of function evaluations
Tnint = total number of segments explored during Cauchy searches
Skip  = number of BFGS updates skipped
Nact  = number of active bounds at final generalized Cauchy point
Projg = norm of the final projected gradient
F     = final function value

           * * *

   N    Tit     Tnf  Tnint  Skip  Nact     Projg        F
  360     31     39      1     0     0   1.085D-05   2.053D+01
  F =   20.534582388676590     

CONVERGENCE: REL_REDUCTION_OF_F_<=_FACTR*EPSMCH             
Computing derivative
Computing Hessian
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
/Users/henriknf/local/src/pyadjoint/pyadjoint/adjfloat.py:309: RuntimeWarning: divide by zero encountered in log
  first_order = float.__mul__(float.__mul__(hessian_input, log(base_value)),
/Users/henriknf/local/src/pyadjoint/pyadjoint/adjfloat.py:316: RuntimeWarning: divide by zero encountered in log
  float.__add__(float.__mul__(exponent_value, log(base_value)), 1)))
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Calling FFC just-in-time (JIT) compiler, this may take some time.
Traceback (most recent call last):
  File "stokes_problem.py", line 275, in <module>
    results = taylor_to_dict(Jhat, Function(S_b), perturbation)
  File "/Users/henriknf/local/src/pyadjoint/pyadjoint/verification.py", line 125, in taylor_to_dict
    Hm = Enlist(J.hessian(hs))
  File "/Users/henriknf/local/src/pyadjoint/pyadjoint/tape.py", line 46, in wrapper
    return function(*args, **kwargs)
  File "/Users/henriknf/local/src/pyadjoint/pyadjoint/reduced_functional.py", line 96, in hessian
    r = compute_hessian(self.functional, self.controls, m_dot, options=options, tape=self.tape)
  File "/Users/henriknf/local/src/pyadjoint/pyadjoint/drivers.py", line 68, in compute_hessian
    tape.evaluate_hessian(markings=True)
  File "/Users/henriknf/local/src/pyadjoint/pyadjoint/tape.py", line 164, in evaluate_hessian
    self._blocks[i].evaluate_hessian(markings=markings)
  File "/Users/henriknf/local/src/pyadjoint/pyadjoint/tape.py", line 46, in wrapper
    return function(*args, **kwargs)
  File "/Users/henriknf/local/src/pyadjoint/pyadjoint/block.py", line 283, in evaluate_hessian
    hessian_output = self.evaluate_hessian_component(inputs,
  File "/Users/henriknf/local/src/pyadjoint/dolfin_adjoint_common/blocks/assembly.py", line 131, in evaluate_hessian_component
    hessian_outputs += adj_input * self.compat.assemble_adjoint_value(ddform)
  File "/Users/henriknf/local/src/pyadjoint/dolfin_adjoint_common/compat.py", line 290, in assemble_adjoint_value
    result = backend.assemble(*args, **kwargs)
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/dolfin/fem/assembling.py", line 198, in assemble
    dolfin_form = _create_dolfin_form(form, form_compiler_parameters)
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/dolfin/fem/assembling.py", line 56, in _create_dolfin_form
    return Form(form,
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/dolfin/fem/form.py", line 43, in __init__
    ufc_form = ffc_jit(form, form_compiler_parameters=form_compiler_parameters,
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/dolfin/jit/jit.py", line 47, in mpi_jit
    return local_jit(*args, **kwargs)
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/dolfin/jit/jit.py", line 97, in ffc_jit
    return ffc.jit(ufl_form, parameters=p)
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/jitcompiler.py", line 217, in jit
    module = jit_build(ufl_object, module_name, parameters)
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/jitcompiler.py", line 130, in jit_build
    module, signature = dijitso.jit(jitable=ufl_object,
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/dijitso/jit.py", line 165, in jit
    header, source, dependencies = generate(jitable, name, signature, params["generator"])
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/jitcompiler.py", line 65, in jit_generate
    code_h, code_c, dependent_ufl_objects = compile_object(ufl_object,
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/compiler.py", line 142, in compile_form
    return compile_ufl_objects(forms, "form", object_names,
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/compiler.py", line 190, in compile_ufl_objects
    ir = compute_ir(analysis, prefix, parameters, jit)
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/representation.py", line 182, in compute_ir
    irs = [_compute_integral_ir(fd, form_id, prefix, element_numbers, classnames, parameters, jit)
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/representation.py", line 182, in <listcomp>
    irs = [_compute_integral_ir(fd, form_id, prefix, element_numbers, classnames, parameters, jit)
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/representation.py", line 455, in _compute_integral_ir
    ir = r.compute_integral_ir(itg_data,
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/uflacs/uflacsrepresentation.py", line 82, in compute_integral_ir
    quadrature_rules, quadrature_rule_sizes = compute_quadrature_rules(
  File "/Users/henriknf/miniconda3/envs/pulse_adjoint/lib/python3.8/site-packages/ffc/uflacs/tools.py", line 64, in compute_quadrature_rules
    assert quadrature_rules[num_points][0] == points
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Adding the following line at the top fixes the problem
```python
parameters["form_compiler"]["quadrature_degree"] = 4
```
