### PR TITLE
Progress bar support

### DIFF
--- a/docs/source/documentation/pyadjoint_api.rst
+++ b/docs/source/documentation/pyadjoint_api.rst
@@ -16,6 +16,7 @@ Core classes
 
     .. automethod:: add_block
     .. automethod:: visualise
+    .. autoproperty:: progress_bar
 
 .. autoclass:: Block
 

--- a/docs/source/documentation/tube-shape-derivative/tube-shape-derivative.rst
+++ b/docs/source/documentation/tube-shape-derivative/tube-shape-derivative.rst
@@ -67,6 +67,7 @@ files are in the mesh directory.
   fout = File("output/u.pvd")
   mesh = Mesh("mesh/cable1.xml")
   bdy_markers = MeshFunction("size_t", mesh, "mesh/cable1_facet_region.xml")
+  original_mesh = Control(mesh)
   
 Then, we define the discrete function spaces. A piecewise linear
 approximation is a suitable choice for the the solution of the advection-diffusion equation.
@@ -245,7 +246,7 @@ Finally, we store the shape derivative for visualisation:
 ::
 
   dJdm = Jhat.derivative()
-  ALE.move(mesh, Function(V), reset_mesh=True)
+  mesh.coordinates()[:] = original_mesh.data()
   
   output = File("output/dJdOmega.pvd")
   out = Function(V)

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -131,7 +131,9 @@ class ReducedFunctional(object):
         blocks = self.tape.get_blocks()
         with self.marked_controls():
             with stop_annotating():
-                for i in range(len(blocks)):
+                for i in self.tape.bar("Evaluating functional").iter(
+                    range(len(blocks))
+                ):
                     blocks[i].recompute()
 
         func_value = self.scale * self.functional.block_variable.checkpoint

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -131,7 +131,7 @@ class ReducedFunctional(object):
         blocks = self.tape.get_blocks()
         with self.marked_controls():
             with stop_annotating():
-                for i in self.tape.bar("Evaluating functional").iter(
+                for i in self.tape._bar("Evaluating functional").iter(
                     range(len(blocks))
                 ):
                     blocks[i].recompute()

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -407,16 +407,15 @@ class Tape(object):
 
     @property
     def progress_bar(self):
-        """Specify progress bar class for tape evaluation.
+        """Specify a progress bar class to print during tape evaluation.
 
-        Setting this attribute to a sublclass of :class:`progress.Bar` will
+        Setting this attribute to a subclass of :class:`progress.Bar` will
         cause every evaluation of a reduced functional, adjoint, TLM or Hessian
         to print a progress bar.
 
         For example, the following code::
 
-            from progress import FillingSquaresBar
-            tape = get_working_tape()
+            from progress import FillingSquaresBar tape = get_working_tape()
             tape.progress_bar = FillingSquaresBar
 
         Will cause tape evaluations to print progress bars similar to the
@@ -424,6 +423,10 @@ class Tape(object):
 
             Evaluating functional ▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣ 100%
             Evaluating adjoint ▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣ 100%
+
+        For information on available progress bar styles and their
+        configuration, see the `progress package documentation
+        <https://pypi.org/project/progress/>`_.
 
         .. note::
 

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -107,8 +107,8 @@ class Tape(object):
         # Keep a list of blocks that has been added to the TensorFlow graph
         self._tf_added_blocks = []
         self._tf_registered_blocks = []
-        # Overwrite this with a :class:`progress.Bar` to see the progress of
-        # tape evaluation operations.
+        # Overwrite this with a :class:`progress.Bar` to see the progress of
+        # tape evaluation operations.
         self.bar = _NullProgressBar
 
     def clear_tape(self):

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -418,7 +418,7 @@ class Tape(object):
             from progress import FillingSquaresBar tape = get_working_tape()
             tape.progress_bar = FillingSquaresBar
 
-        Will cause tape evaluations to print progress bars similar to the
+        will cause tape evaluations to print progress bars similar to the
         following::
 
             Evaluating functional ▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣ 100%

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -415,7 +415,8 @@ class Tape(object):
 
         For example, the following code::
 
-            from progress import FillingSquaresBar tape = get_working_tape()
+            from progress import FillingSquaresBar
+            tape = get_working_tape()
             tape.progress_bar = FillingSquaresBar
 
         will cause tape evaluations to print progress bars similar to the


### PR DESCRIPTION
Often when debugging code using pyadjoint, it would be handy to have some feedback about the evaluation of the tape. Python has various progress bar packages available which support this. This PR adds support for adding progress bars to tape evaluations:

```
...
from progress.bar import FillingSquaresBar
tape = get_working_tape()
tape.progress_bar = FillingSquaresBar
```

Now every evaluation of a ReducedFunctional, adjoint, TLM, or Hessian will be accompanied by a progress bar:
```
Evaluating functional ▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣ 100%
Evaluating adjoint ▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣ 100%
Evaluating functional ▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣ 100%
Evaluating adjoint ▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣▣ 100%
```

The `progress_bar` property has a docstring which also appears in the web documentation for the tape.