### PR TITLE
Improved tape visualisation

### DIFF
--- a/dolfin_adjoint_common/blocks/assembly.py
+++ b/dolfin_adjoint_common/blocks/assembly.py
@@ -1,4 +1,5 @@
 import ufl
+from ufl.formatting.ufl2unicode import ufl2unicode
 from pyadjoint import Block, create_overloaded_object
 
 
@@ -15,7 +16,7 @@ class AssembleBlock(Block):
             self.add_dependency(c, no_duplicates=True)
 
     def __str__(self):
-        return str(self.form)
+        return f"assemble({ufl2unicode(self.form)})"
 
     def prepare_evaluate_adj(self, inputs, adj_inputs, relevant_dependencies):
         replaced_coeffs = {}

--- a/dolfin_adjoint_common/blocks/function.py
+++ b/dolfin_adjoint_common/blocks/function.py
@@ -1,5 +1,6 @@
 import ufl
 from ufl.corealg.traversal import traverse_unique_terminals
+from ufl.formatting.ufl2unicode import ufl2unicode
 from pyadjoint import Block, OverloadedType, AdjFloat
 
 
@@ -139,3 +140,11 @@ class FunctionAssignBlock(Block):
         output = self.backend.Function(block_variable.output.function_space())
         self.backend.Function.assign(output, prepared)
         return output
+
+    def __str__(self):
+        rhs = self.expr or self.other or self.get_dependencies()[0].output
+        if isinstance(rhs, ufl.core.expr.Expr):
+            rhs_str = ufl2unicode(rhs)
+        else:
+            rhs_str = str(rhs)
+        return f"assign({rhs_str})"

--- a/dolfin_adjoint_common/blocks/solving.py
+++ b/dolfin_adjoint_common/blocks/solving.py
@@ -1,5 +1,6 @@
 import numpy
 import ufl
+from ufl.formatting.ufl2unicode import ufl2unicode
 
 from pyadjoint import Block
 from pyadjoint.enlisting import Enlist
@@ -63,7 +64,8 @@ class GenericSolveBlock(Block):
         self.assemble_kwargs = {}
 
     def __str__(self):
-        return "{} = {}".format(str(self.lhs), str(self.rhs))
+        return "solve({} = {})".format(ufl2unicode(self.lhs),
+                                       ufl2unicode(self.rhs))
 
     def _create_F_form(self):
         # Process the equation forms, replacing values with checkpoints,

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -351,16 +351,19 @@ class Tape(object):
 
     def visualise(self, output="log", launch_tensorboard=False, open_in_browser=False):
         """Makes a visualisation of the tape as a graph using TensorFlow
-        or GraphViz. (Default: Tensorflow). If `output` endswith `.dot`,
-        Graphviz is used.
+        or GraphViz. (Default: Tensorflow). If `output` endswith `.dot` or
+        `.pdf`, Graphviz is used.
 
         Args:
-            output (str): Directory where event files for TensorBoard is stored. Default log.
-            launch_tensorboard (bool): Launch TensorBoard in the background. Default False.
-            open_in_browser (bool): Opens http://localhost:6006/ in a web browser. Default False.
+            output (str): Directory where event files for TensorBoard is
+            stored. Default log. launch_tensorboard (bool): Launch TensorBoard
+            in the background. Default False. open_in_browser (bool): Opens
+            http://localhost:6006/ in a web browser. Default False.
         """
         if output.endswith(".dot"):
             return self.visualise_dot(output)
+        elif output.endswith(".pdf"):
+            return self.visualise_pdf(output)
 
         import tensorflow as tf
         tf.compat.v1.reset_default_graph()
@@ -404,6 +407,29 @@ class Tape(object):
         G = self.create_graph()
         from networkx.drawing.nx_agraph import write_dot
         write_dot(G, filename)
+
+    def visualise_pdf(self, filename):
+        """Create a PDF visualisation of the tape.
+
+        This depends on the Python package networkx and the external Graphviz
+        package. The latter can be installed using e.g.::
+
+            sudo apt install graphviz
+
+        on Ubuntu or::
+
+            brew install graphviz
+
+        on Mac.
+
+        Args:
+            filename (str): File to save the visualisation. Must end in .pdf.
+        """
+        if not filename.endswith(".pdf"):
+            raise ValueError("Filename for PDF output must end in .pdf")
+        from networkx.drawing.nx_agraph import to_agraph
+        A = to_agraph(self.create_graph())
+        A.draw(filename, prog="dot")
 
     @property
     def progress_bar(self):


### PR DESCRIPTION
Tape visualisation using graphs is very handy for debugging and understanding what pyadjoint does.

This PR improves the readability of the tape graph in Dolfin_adjoint and Firedrake-adjoint by changing the rendering of UFL objects from `str` to `ufl2unicode`. This produces tape visualisations that are much easier for the user to read.

The PR also introduces convenience functionality that enables users to directly generate pdf tape visualisations. This is probably the main user use of the visualisation functionality, so it makes sense to make it as easy as possible.