### PR TITLE
Convert ROLObjective to handle update flag

### DIFF
--- a/pyadjoint/optimization/rol_solver.py
+++ b/pyadjoint/optimization/rol_solver.py
@@ -36,17 +36,11 @@ try:
                 # Temp: temporary
                 if flag in [ROL.UpdateType.Initial, ROL.UpdateType.Trial, ROL.UpdateType.Temp]:
                     self._val = self.rf(x.dat)
-                    self._tape_trial = self.rf.tape.block_vars(self.rf.controls)
+                    self._tape_trial = self.rf.tape.checkpoint_block_vars(self.rf.controls)
                 elif flag == ROL.UpdateType.Revert:
                     # revert back to the cached value
                     self._val = self._cache
-                    for k, v in self._tape_cache.items():
-                        # we use the private _checkpoint attribute
-                        # here because the public attribute is a no-op
-                        # if the control values are "active", but we
-                        # need to make sure they are reset to the
-                        # cached value as well
-                        k._checkpoint = v
+                    self.rf.tape.restore_block_vars(self._tape_cache)
 
                 self._flag = flag
 

--- a/pyadjoint/optimization/rol_solver.py
+++ b/pyadjoint/optimization/rol_solver.py
@@ -36,7 +36,7 @@ try:
                 # Temp: temporary
                 if flag in [ROL.UpdateType.Initial, ROL.UpdateType.Trial, ROL.UpdateType.Temp]:
                     self._val = self.rf(x.dat)
-                    self._tape_trial = self.rf.tape.block_vars()
+                    self._tape_trial = self.rf.tape.block_vars(self.rf.controls)
                 elif flag == ROL.UpdateType.Revert:
                     # revert back to the cached value
                     self._val = self._cache

--- a/pyadjoint/optimization/rol_solver.py
+++ b/pyadjoint/optimization/rol_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from .optimization_solver import OptimizationSolver
 from ..enlisting import Enlist
 from ..overloaded_type import OverloadedType
@@ -14,13 +12,15 @@ try:
             self.rf = rf
             self.scale = scale
 
+            self._val = None
+            self._cache = None
+            self._flag = None
+
         def value(self, x, tol):
-            # FIXME: should check if we have evaluated here before
-            return self.val
+            return self._val
 
         def gradient(self, g, x, tol):
-            # self.rf(x.dat)
-            self.deriv = self.rf.derivative()  # forget=False, project=False)
+            self.deriv = self.rf.derivative()
             g.dat = g.riesz_map(self.deriv)
 
         def hessVec(self, hv, v, x, tol):
@@ -28,8 +28,35 @@ try:
             hv.dat = hv.riesz_map(hessian_action)
 
         def update(self, x, flag, iteration):
-            self.val = self.rf(x.dat)
-            # pass
+            if hasattr(ROL, "UpdateType") and isinstance(flag, ROL.UpdateType):
+                # Initial: has not been called before
+                # Accept: this is the new iterate, trial has been called
+                # Revert: revert to previous, trial has been called
+                # Trial: candidate for next
+                # Temp: temporary
+                if flag in [ROL.UpdateType.Initial, ROL.UpdateType.Trial, ROL.UpdateType.Temp]:
+                    self._val = self.rf(x.dat)
+                    self._tape_trial = self.rf.tape.block_vars()
+                elif flag == ROL.UpdateType.Revert:
+                    # revert back to the cached value
+                    self._val = self._cache
+                    for k, v in self._tape_cache.items():
+                        # we use the private _checkpoint attribute
+                        # here because the public attribute is a no-op
+                        # if the control values are "active", but we
+                        # need to make sure they are reset to the
+                        # cached value as well
+                        k._checkpoint = v
+
+                self._flag = flag
+
+                # cache value/tape in the first instance or when accepted
+                if flag in [ROL.UpdateType.Initial, ROL.UpdateType.Accept]:
+                    self._cache = self._val
+                    self._tape_cache = self._tape_trial
+
+            else:
+                self._val = self.rf(x.dat)
 
     class ROLVector(ROL.Vector):
         def __init__(self, dat, inner_product="L2"):

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -4,6 +4,7 @@ import re
 import threading
 from contextlib import contextmanager
 from functools import wraps
+from itertools import chain
 
 _working_tape = None
 _stop_annotating = 0
@@ -192,6 +193,18 @@ class Tape(object):
         """
         # TODO: Offer deepcopying. But is it feasible memory wise to copy all checkpoints?
         return Tape(blocks=self._blocks[:])
+
+    def block_vars(self, tag=None):
+        """Return a dictionary mapping all block variables on the tape to their checkpointed values"""
+
+        return {
+            var: var.checkpoint
+            for var in chain.from_iterable(
+                chain(
+                    b.get_dependencies(),
+                    b.get_outputs()
+                ) for b in self.get_blocks(tag))
+        }
 
     def optimize(self, controls=None, functionals=None):
         if controls is not None:

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -194,16 +194,16 @@ class Tape(object):
         # TODO: Offer deepcopying. But is it feasible memory wise to copy all checkpoints?
         return Tape(blocks=self._blocks[:])
 
-    def block_vars(self, tag=None):
-        """Return a dictionary mapping all block variables on the tape to their checkpointed values"""
+    def block_vars(self, controls=[], tag=None):
+        """Return a dictionary mapping all block variables on the tape to their checkpointed values.
+
+        May optionally take a list of controls for which the block variables should also be extracted."""
 
         return {
             var: var.checkpoint
-            for var in chain.from_iterable(
-                chain(
-                    b.get_dependencies(),
-                    b.get_outputs()
-                ) for b in self.get_blocks(tag))
+            for var in chain(
+                chain.from_iterable(b.get_outputs() for b in self.get_blocks(tag)),
+                (control.block_variable for control in controls))
         }
 
     def optimize(self, controls=None, functionals=None):

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -194,10 +194,16 @@ class Tape(object):
         # TODO: Offer deepcopying. But is it feasible memory wise to copy all checkpoints?
         return Tape(blocks=self._blocks[:])
 
-    def block_vars(self, controls=[], tag=None):
-        """Return a dictionary mapping all block variables on the tape to their checkpointed values.
+    def checkpoint_block_vars(self, controls=[], tag=None):
+        """Returns an object to checkpoint the current state of all block variables on the tape.
 
-        May optionally take a list of controls for which the block variables should also be extracted."""
+        Args:
+            controls (list): A list of controls for which the block variables should also be extracted.
+
+        Returns:
+            dict[BlockVariable, object]: The checkpointed block variables of the tape.
+
+        """
 
         return {
             var: var.checkpoint
@@ -205,6 +211,22 @@ class Tape(object):
                 chain.from_iterable(b.get_outputs() for b in self.get_blocks(tag)),
                 (control.block_variable for control in controls))
         }
+
+    def restore_block_vars(self, block_vars):
+        """Set the checkpoints of the tape according to a checkpoint dictionary.
+
+        Args:
+            block_vars (dict[BlockVariable, object]): A checkpoint object from checkpoint_block_vars.
+
+        """
+
+        for k, v in block_vars.items():
+            # we use the private _checkpoint attribute
+            # here because the public attribute is a no-op
+            # if the control values are "active", but we
+            # need to make sure they are reset to the
+            # cached value as well
+            k._checkpoint = v
 
     def optimize(self, controls=None, functionals=None):
         if controls is not None:


### PR DESCRIPTION
ROL 2.0 calls the objective update method with a flag describing why the call was taken. This allows us to implement a caching scheme, to accept or revert updates if necessary. Ultimately, this can save quite a few objective function evaluations.

Because the ROL 2.0 update is very widely split, this change is backwards compatible, and will only be effective if pyrol wraps the UpdateType enumeration (e.g. https://github.com/angus-g/pyrol/commit/1c192fa6d8ffd0ae7f2648f9e38728f6ea546feb)

This supersedes #78. I did expect the changes to be incompatible, but they ended up fairly similar. I've added some extra machinery to the tape to give us a map of block variables to their checkpointed values, which allows us to restore the tape to a consistent state that lets us re-evaluate the gradient correctly after a rejected trial.