### PR TITLE
Firedrake disk checkpoints

### DIFF
--- a/firedrake_adjoint/__init__.py
+++ b/firedrake_adjoint/__init__.py
@@ -14,6 +14,11 @@ from pyadjoint.tape import (Tape, set_working_tape, get_working_tape,
                             pause_annotation, continue_annotation,
                             stop_annotating, annotate_tape)
 from pyadjoint.reduced_functional import ReducedFunctional
+from firedrake.adjoint.checkpointing import (
+    enable_disk_checkpointing, pause_disk_checkpointing,
+    continue_disk_checkpointing, stop_disk_checkpointing,
+    checkpointable_mesh
+)
 from pyadjoint.verification import taylor_test, taylor_to_dict
 from pyadjoint.drivers import compute_gradient, compute_hessian
 from pyadjoint.adjfloat import AdjFloat

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -333,7 +333,7 @@ class FloatingType(OverloadedType):
         if self._ad_floating_active:
             with FloatingType.stop_floating(self):
                 self._ad_annotate_block()
-        self.block_variable.save_output(overwrite=True)
+        self.block_variable.save_output(overwrite=False)
 
     def _ad_will_add_as_output(self):
         if self._ad_floating_active:

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -1,6 +1,7 @@
 from .drivers import compute_gradient, compute_hessian
 from .enlisting import Enlist
 from .tape import get_working_tape, stop_annotating, no_annotations
+from .overloaded_type import OverloadedType
 
 
 class ReducedFunctional(object):
@@ -27,6 +28,8 @@ class ReducedFunctional(object):
                  derivative_cb_post=lambda *args: None,
                  hessian_cb_pre=lambda *args: None,
                  hessian_cb_post=lambda *args: None):
+        if not isinstance(functional, OverloadedType):
+            raise TypeError("Functional must be an OveroadedType.")
         self.functional = functional
         self.tape = get_working_tape() if tape is None else tape
         self.controls = Enlist(controls)

--- a/tests/firedrake_adjoint/test_disk_checkpointing.py
+++ b/tests/firedrake_adjoint/test_disk_checkpointing.py
@@ -1,0 +1,76 @@
+from firedrake import *
+from firedrake_adjoint import *
+from firedrake.adjoint.checkpointing import disk_checkpointing
+import numpy as np
+import os
+
+
+def adjoint_example(fine, coarse):
+    dg_space = FunctionSpace(fine, "DG", 1)
+    cg_space = FunctionSpace(fine, "CG", 2)
+    W = dg_space * cg_space
+
+    w = Function(W)
+
+    x, y = SpatialCoordinate(fine)
+    # InterpolateBlock
+    m = interpolate(sin(4*pi*x)*cos(4*pi*y), cg_space)
+
+    u, v = w.split()
+    # FunctionAssignBlock, FunctionMergeBlock
+    v.assign(m)
+    # FunctionSplitBlock, GenericSolveBlock
+    u.project(v)
+
+    dg_space_c = FunctionSpace(coarse, "DG", 1)
+    cg_space_c = FunctionSpace(coarse, "CG", 2)
+
+    # SupermeshProjectBlock
+    u_c = project(u, dg_space_c)
+    v_c = project(v, cg_space_c)
+
+    # AssembleBlock
+    J = assemble((u_c - v_c)**2 * dx)
+
+    Jhat = ReducedFunctional(J, Control(m))
+
+    with stop_annotating():
+        m_new = interpolate(sin(4*pi*x)*cos(4*pi*y), cg_space)
+    checkpointer = get_working_tape()._package_data["firedrake"]
+    init_file_timestamp = os.stat(checkpointer.init_checkpoint_file.name).st_mtime
+    current_file_timestamp = os.stat(checkpointer.current_checkpoint_file.name).st_mtime
+    Jnew = Jhat(m_new)
+    # Check that any new disk checkpoints are written to the correct file.
+    assert init_file_timestamp == os.stat(checkpointer.init_checkpoint_file.name).st_mtime
+    assert current_file_timestamp < os.stat(checkpointer.current_checkpoint_file.name).st_mtime
+
+    assert np.allclose(J, Jnew)
+
+    grad_Jnew = Jhat.derivative()
+
+    return Jnew, grad_Jnew
+
+
+def test_disk_checkpointing():
+    # Use a Firedrake Tape subclass that supports disk checkpointing.
+    set_working_tape(Tape())
+    tape = get_working_tape()
+    tape.clear_tape()
+    enable_disk_checkpointing()
+
+    fine = checkpointable_mesh(UnitSquareMesh(10, 10, name="fine"))
+    coarse = checkpointable_mesh(UnitSquareMesh(4, 4, name="coarse"))
+    J_disk, grad_J_disk = adjoint_example(fine, coarse)
+
+    tape.clear_tape()
+    pause_disk_checkpointing()
+
+    J_mem, grad_J_mem = adjoint_example(fine, coarse)
+
+    assert np.allclose(J_disk, J_mem)
+    assert np.allclose(assemble((grad_J_disk - grad_J_mem)**2*dx), 0.0)
+    tape.clear_tape()
+
+
+if __name__ == "__main__":
+    test_disk_checkpointing()

--- a/tests/firedrake_adjoint/test_external_modification.py
+++ b/tests/firedrake_adjoint/test_external_modification.py
@@ -1,0 +1,26 @@
+import pytest
+pytest.importorskip("firedrake")
+
+from firedrake import *
+from firedrake_adjoint import *
+import numpy as np
+
+
+def test_external_modification():
+    mesh = UnitSquareMesh(2, 2)
+    fs = FunctionSpace(mesh, 'CG', 1)
+
+    u = Function(fs)
+    v1 = Function(fs)
+    v2 = Function(fs)
+
+    u.assign(1.)
+    v1.project(u)
+    with stop_annotating(modifies=u):
+        u.dat.data[:] = 2.
+    v2.project(u)
+
+    J = assemble(v1*dx + v2*dx)
+    Jhat = ReducedFunctional(J, Control(u))
+
+    assert np.allclose(J, Jhat(2))


### PR DESCRIPTION
This PR primarily adds the facility for packages that use pyadjoint to attach their own state information to the tape and have it respond appropriately to tape events such as copy, clear, and reset. 

This is done to enable Firedrake disk checkpointing so there is also a small change to the `firedrake_adjoint` module and an additional test.