### PR TITLE
ReducedFunction

### DIFF
--- a/dolfin_adjoint_common/blocks/function.py
+++ b/dolfin_adjoint_common/blocks/function.py
@@ -13,7 +13,7 @@ class FunctionAssignBlock(Block):
             other = AdjFloat(other)
         if isinstance(other, OverloadedType):
             self.add_dependency(other, no_duplicates=True)
-        elif not(isinstance(other, float) or isinstance(other, int)):
+        elif not (isinstance(other, float) or isinstance(other, int)):
             # Assume that this is a point-wise evaluated UFL expression (firedrake only)
             for op in traverse_unique_terminals(other):
                 if isinstance(op, OverloadedType):

--- a/firedrake_adjoint/__init__.py
+++ b/firedrake_adjoint/__init__.py
@@ -20,7 +20,7 @@ from firedrake.adjoint.checkpointing import (
     checkpointable_mesh
 )
 from pyadjoint.verification import taylor_test, taylor_to_dict
-from pyadjoint.drivers import compute_gradient, compute_hessian
+from pyadjoint.drivers import compute_gradient, compute_jacobian_action, compute_hessian
 from pyadjoint.adjfloat import AdjFloat
 from pyadjoint.control import Control
 from pyadjoint import IPOPTSolver, ROLSolver, MinimizationProblem, InequalityConstraint, minimize

--- a/numpy_adjoint/array.py
+++ b/numpy_adjoint/array.py
@@ -6,18 +6,54 @@ from pyadjoint.block import Block
 
 @register_overloaded_type
 class ndarray(OverloadedType, numpy.ndarray):
+    @classmethod
     def __init__(self, *args, **kwargs):
         pass
 
+    def __array_finalize__(self, obj):
+        OverloadedType.__init__(self)
+
     @classmethod
     def _ad_init_object(cls, obj):
-        return cls(obj.shape, numpy.float_, buffer=obj)
+        obj = numpy.array(obj, subok=True)
+        return cls(obj.shape, dtype=obj.dtype, buffer=obj.data, strides=obj.strides)
 
     def _ad_create_checkpoint(self):
         return self.copy()
 
     def _ad_restore_at_checkpoint(self, checkpoint):
         return checkpoint
+
+    def _ad_convert_type(self, value, options={}):
+        return value
+
+    def _ad_dim(self):
+        return self.size
+
+    def _ad_dot(self, other):
+        return numpy.dot(self.flat, other.flat)
+
+    def _ad_mul(self, other):
+        return self * other
+
+    def _ad_add(self, other):
+        return self + other
+
+    def _ad_copy(self):
+        return self.copy()
+
+    def copy(self, *args, **kwargs):
+        return create_overloaded_object(super().copy(*args, **kwargs))
+
+    @staticmethod
+    def _ad_assign_numpy(dst, src, offset):
+        dst = numpy.reshape(src[offset:offset + dst.size], dst.shape)
+        offset += dst.size
+        return dst, offset
+
+    @staticmethod
+    def _ad_to_list(self):
+        return self.flatten().tolist()
 
     def __getitem__(self, item):
         annotate = annotate_tape()
@@ -34,12 +70,6 @@ class ndarray(OverloadedType, numpy.ndarray):
             block.add_output(out.create_block_variable())
         return out
 
-    def _ad_convert_type(self, value, options={}):
-        return value
-
-    def __array_finalize__(self, obj):
-        OverloadedType.__init__(self)
-
 
 class NumpyArraySliceBlock(Block):
     def __init__(self, array, item):
@@ -54,3 +84,6 @@ class NumpyArraySliceBlock(Block):
 
     def recompute_component(self, inputs, block_variable, idx, prepared):
         return inputs[0][self.item]
+
+    def evaluate_tlm_component(self, inputs, tlm_inputs, block_variable, idx, prepared=None):
+        return tlm_inputs[0][self.item]

--- a/numpy_adjoint/array.py
+++ b/numpy_adjoint/array.py
@@ -6,7 +6,6 @@ from pyadjoint.block import Block
 
 @register_overloaded_type
 class ndarray(OverloadedType, numpy.ndarray):
-    @classmethod
     def __init__(self, *args, **kwargs):
         pass
 

--- a/pyadjoint/__init__.py
+++ b/pyadjoint/__init__.py
@@ -12,7 +12,7 @@ from .tape import (Tape,
                    set_working_tape, get_working_tape, no_annotations,
                    annotate_tape, stop_annotating, pause_annotation, continue_annotation)
 from .adjfloat import AdjFloat
-from .reduced_functional import ReducedFunctional
+from .reduced_functional import ReducedFunction, ReducedFunctional
 from .drivers import compute_gradient, compute_hessian, solve_adjoint
 from .verification import taylor_test, taylor_to_dict
 from .overloaded_type import OverloadedType, create_overloaded_object

--- a/pyadjoint/__init__.py
+++ b/pyadjoint/__init__.py
@@ -13,6 +13,7 @@ from .tape import (Tape,
                    annotate_tape, stop_annotating, pause_annotation, continue_annotation)
 from .adjfloat import AdjFloat
 from .reduced_functional import ReducedFunction, ReducedFunctional
+from .reduced_functional_numpy import ReducedFunctionNumPy, ReducedFunctionalNumPy
 from .drivers import compute_gradient, compute_hessian, solve_adjoint
 from .verification import taylor_test, taylor_to_dict
 from .overloaded_type import OverloadedType, create_overloaded_object

--- a/pyadjoint/__init__.py
+++ b/pyadjoint/__init__.py
@@ -14,7 +14,7 @@ from .tape import (Tape,
 from .adjfloat import AdjFloat
 from .reduced_functional import ReducedFunction, ReducedFunctional
 from .reduced_functional_numpy import ReducedFunctionNumPy, ReducedFunctionalNumPy
-from .drivers import compute_gradient, compute_hessian, solve_adjoint
+from .drivers import compute_gradient, compute_hessian, compute_jacobian_action, solve_adjoint
 from .verification import taylor_test, taylor_to_dict
 from .overloaded_type import OverloadedType, create_overloaded_object
 from .control import Control

--- a/pyadjoint/adjfloat.py
+++ b/pyadjoint/adjfloat.py
@@ -112,7 +112,7 @@ class AdjFloat(OverloadedType, float):
 
     @staticmethod
     def _ad_assign_numpy(dst, src, offset):
-        dst = type(dst)(src[offset:offset + 1])
+        dst = type(dst)(src[offset])
         offset += 1
         return dst, offset
 
@@ -124,6 +124,7 @@ class AdjFloat(OverloadedType, float):
         return self
 
 
+register_overloaded_type(AdjFloat, int)
 _min = min
 _max = max
 

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -1,4 +1,5 @@
 from .block_variable import BlockVariable
+from .enlisting import Enlist
 from .tape import get_working_tape
 
 _overloaded_types = {}
@@ -36,6 +37,10 @@ def create_overloaded_object(obj, suppress_warning=False):
             import warnings
             warnings.warn("Could not find overloaded class of type '{}'.".format(obj_type), stacklevel=2)
         return obj
+
+
+def create_overloaded_objects(seq):
+    return [create_overloaded_object(v) for v in Enlist(seq)]
 
 
 def register_overloaded_type(overloaded_type, classes=None):

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -1,10 +1,229 @@
+from functools import wraps
 from .drivers import compute_gradient, compute_hessian
 from .enlisting import Enlist
 from .tape import get_working_tape, stop_annotating, no_annotations
 from .overloaded_type import OverloadedType
 
 
-class ReducedFunctional(object):
+class ReducedFunction(object):
+    """Class representing the reduced function.
+
+    A reduced function maps a control value to the provided function.
+    It may also be used to compute the derivative of the function with
+    respect to the control.
+
+    Args:
+        outputs (:obj:`OverloadedType`): An instance of an OverloadedType,
+            usually :class:`AdjFloat`. This should be the return value of the
+            function you want to reduce. It may also be a list instead of a
+            single OverloadedType instance.
+        controls (list[Control]): A list of Control instances, which you want
+            to map to the outputs. It is also possible to supply a single Control
+            instance instead of a list.
+    """
+    def __init__(
+        self,
+        outputs,
+        controls,
+        tape=None,
+        eval_cb_pre=None,
+        eval_cb_post=None,
+        jac_action_cb_pre=None,
+        jac_action_cb_post=None,
+        adj_jac_action_cb_pre=None,
+        adj_jac_action_cb_post=None,
+        hess_action_cb_pre=None,
+        hess_action_cb_post=None,
+    ):
+        self.output_vals = Enlist(outputs)
+        for out in self.output_vals:
+            if not isinstance(out, OverloadedType):
+                raise TypeError(f"output must be an OverloadedType: {out}")
+        self.outputs = Enlist([out.block_variable for out in self.output_vals])
+        self.outputs.listed = self.output_vals.listed
+
+        self.controls = Enlist(controls)
+        self.tape = get_working_tape() if tape is None else tape
+
+        nothing = lambda *args: None
+        self.eval_cb_pre = nothing if eval_cb_pre is None else eval_cb_pre
+        self.eval_cb_post = nothing if eval_cb_post is None else eval_cb_post
+        self.jac_action_cb_pre = (
+            nothing if jac_action_cb_pre is None else jac_action_cb_pre
+        )
+        self.jac_action_cb_post = (
+            nothing if jac_action_cb_post is None else jac_action_cb_post
+        )
+        self.adj_jac_action_cb_pre = (
+            nothing if adj_jac_action_cb_pre is None else adj_jac_action_cb_pre
+        )
+        self.adj_jac_action_cb_post = (
+            nothing if adj_jac_action_cb_post is None else adj_jac_action_cb_post
+        )
+        self.hess_action_cb_pre = (
+            nothing if hess_action_cb_pre is None else hess_action_cb_pre
+        )
+        self.hess_action_cb_post = (
+            nothing if hess_action_cb_post is None else hess_action_cb_post
+        )
+
+    @no_annotations
+    def adj_jac_action(self, adj_input, options=None):
+        """Returns the action of the adjoint Jacobian of the function w.r.t. the
+        control on a vector adj_input.
+
+        Using the adjoint method, the action of the adjoint Jacobian with
+        respect to the control, around the last supplied value of the control,
+        is computed and returned.
+
+        Args:
+            options (dict): A dictionary of options. To find a list of available
+                options have a look at the specific control type.
+
+        Returns:
+            OverloadedType: The action of the Jacobian with respect to the control.
+                Should be an instance of the same type as the control.
+        """
+        adj_input = Enlist(adj_input)
+        if len(adj_input) != len(self.outputs):
+            raise ValueError(
+                "The length of adj_input must match the length of function outputs."
+            )
+
+        values = [c.tape_value() for c in self.controls]
+        self.adj_jac_action_cb_pre(self.controls.delist(values))
+
+        derivatives = compute_gradient(
+            self.output_vals,
+            self.controls,
+            options=options,
+            tape=self.tape,
+            adj_value=adj_input,
+        )
+
+        # Call callback
+        self.adj_jac_action_cb_post(
+            self.outputs.delist([bv.saved_output for bv in self.outputs]),
+            self.controls.delist(derivatives),
+            self.controls.delist(values),
+        )
+
+        return self.controls.delist(derivatives)
+
+    @no_annotations
+    def hess_action(self, m_dot, adj_input, options=None):
+        """Returns the action of the Hessian of the function w.r.t. the
+        control on the vectors m_dot and adj_input.
+
+        Using the second-order adjoint method, the action of the Hessian of the
+        function with respect to the control, around the last supplied value
+        of the control, is computed and returned.
+
+        Args:
+            m_dot ([OverloadedType]): The direction in which to compute the
+                action of the Hessian.
+            adj_input ([OverloadedType]): The adjoint direction in which to
+                compute the action of the Hessian.
+            options (dict): A dictionary of options. To find a list of
+                available options have a look at the specific control type.
+
+        Returns:
+            OverloadedType: The action of the Hessian in the direction m_dot.
+                Should be an instance of the same type as the control.
+        """
+        m_dot = Enlist(m_dot)
+        if len(m_dot) != len(self.controls):
+            raise ValueError(
+                "The length of m_dot must match the length of function controls."
+            )
+
+        adj_input = Enlist(adj_input)
+        if len(adj_input) != len(self.outputs):
+            raise ValueError(
+                "The length of adj_input must match the length of function outputs."
+            )
+
+        values = [c.tape_value() for c in self.controls]
+        self.hess_action_cb_pre(self.controls.delist(values))
+
+        compute_gradient(
+            self.output_vals,
+            self.controls,
+            options=options,
+            tape=self.tape,
+            adj_value=adj_input,
+        )
+
+        # TODO: there should be a better way of generating hessian_value.
+        zero = [0 * v for v in adj_input]
+        hessian = compute_hessian(
+            self.output_vals,
+            self.controls,
+            m_dot,
+            options=options,
+            tape=self.tape,
+            hessian_value=zero,
+        )
+
+        # Call callback
+        self.hess_action_cb_post(
+            self.outputs.delist([bv.saved_output for bv in self.outputs]),
+            self.controls.delist(hessian),
+            self.controls.delist(values),
+        )
+
+        return self.controls.delist(hessian)
+
+    @no_annotations
+    def __call__(self, inputs):
+        """Computes the reduced function with supplied control value.
+
+        Args:
+            inputs ([OverloadedType]): If you have multiple controls this should be a list of
+                new values for each control in the order you listed the controls to the constructor.
+                If you have a single control it can either be a list or a single object.
+                Each new value should have the same type as the corresponding control.
+
+        Returns:
+            :obj:`OverloadedType`: The computed value. Typically of instance
+                of :class:`AdjFloat`.
+
+        """
+        inputs = Enlist(inputs)
+        if len(inputs) != len(self.controls):
+            raise ValueError("The length of inputs must match the length of controls.")
+
+        # Call callback.
+        self.eval_cb_pre(self.controls.delist(inputs))
+
+        for i, value in enumerate(inputs):
+            self.controls[i].update(value)
+
+        self.tape.reset_blocks()
+        with self.marked_controls():
+            with stop_annotating():
+                self.tape.recompute()
+
+        output_vals = self.outputs.delist(
+            [output.saved_output for output in self.outputs]
+        )
+
+        # Call callback
+        self.eval_cb_post(output_vals, self.controls.delist(inputs))
+
+        return output_vals
+
+    def optimize_tape(self):
+        self.tape.optimize(
+            controls=self.controls,
+            functionals=self.output_vals
+        )
+
+    def marked_controls(self):
+        return marked_controls(self)
+
+
+class ReducedFunctional(ReducedFunction):
     """Class representing the reduced functional.
 
     A reduced functional maps a control value to the provided functional.
@@ -18,28 +237,68 @@ class ReducedFunctional(object):
         controls (list[Control]): A list of Control instances, which you want
             to map to the functional. It is also possible to supply a single Control
             instance instead of a list.
-
     """
 
-    def __init__(self, functional, controls, scale=1.0, tape=None,
-                 eval_cb_pre=lambda *args: None,
-                 eval_cb_post=lambda *args: None,
-                 derivative_cb_pre=lambda *args: None,
-                 derivative_cb_post=lambda *args: None,
-                 hessian_cb_pre=lambda *args: None,
-                 hessian_cb_post=lambda *args: None):
-        if not isinstance(functional, OverloadedType):
-            raise TypeError("Functional must be an OveroadedType.")
+    def __init__(self, functional, controls, scale=1.0,
+                 derivative_cb_pre=None,
+                 derivative_cb_post=None,
+                 hessian_cb_pre=None,
+                 hessian_cb_post=None,
+                 **kwargs):
         self.functional = functional
-        self.tape = get_working_tape() if tape is None else tape
-        self.controls = Enlist(controls)
         self.scale = scale
-        self.eval_cb_pre = eval_cb_pre
-        self.eval_cb_post = eval_cb_post
-        self.derivative_cb_pre = derivative_cb_pre
-        self.derivative_cb_post = derivative_cb_post
-        self.hessian_cb_pre = hessian_cb_pre
-        self.hessian_cb_post = hessian_cb_post
+        return super().__init__(
+            functional,
+            controls,
+            adj_jac_action_cb_pre=derivative_cb_pre,
+            adj_jac_action_cb_post=derivative_cb_post,
+            hess_action_cb_pre=hessian_cb_pre,
+            hess_action_cb_post=hessian_cb_post,
+            **kwargs
+        )
+
+    @property
+    def eval_cb_post(self):
+        return self._eval_cb_post
+
+    @eval_cb_post.setter
+    def eval_cb_post(self, func):
+        @wraps(func)
+        def eval_cb_post_with_scale(func_value, *args):
+            return func(func_value * self.scale, *args)
+        self._eval_cb_post = eval_cb_post_with_scale
+
+    @property
+    def derivative_cb_pre(self):
+        return self.adj_jac_action_cb_pre
+
+    @derivative_cb_pre.setter
+    def derivative_cb_pre(self, val):
+        self.adj_jac_action_cb_pre = val
+
+    @property
+    def derivative_cb_post(self):
+        return self.adj_jac_action_cb_post
+
+    @derivative_cb_post.setter
+    def derivative_cb_post(self, val):
+        self.adj_jac_action_cb_post = val
+
+    @property
+    def hessian_cb_pre(self):
+        return self.hess_action_cb_pre
+
+    @hessian_cb_pre.setter
+    def hessian_cb_pre(self, val):
+        self.hess_action_cb_pre = val
+
+    @property
+    def hessian_cb_post(self):
+        return self.hess_action_cb_post
+
+    @hessian_cb_post.setter
+    def hessian_cb_post(self, val):
+        self.hess_action_cb_post = val
 
     def derivative(self, options={}):
         """Returns the derivative of the functional w.r.t. the control.
@@ -57,22 +316,7 @@ class ReducedFunctional(object):
                 Should be an instance of the same type as the control.
 
         """
-        # Call callback
-        values = [c.tape_value() for c in self.controls]
-        self.derivative_cb_pre(self.controls.delist(values))
-
-        derivatives = compute_gradient(self.functional,
-                                       self.controls,
-                                       options=options,
-                                       tape=self.tape,
-                                       adj_value=self.scale)
-
-        # Call callback
-        self.derivative_cb_post(self.functional.block_variable.checkpoint,
-                                self.controls.delist(derivatives),
-                                self.controls.delist(values))
-
-        return self.controls.delist(derivatives)
+        return self.adj_jac_action(self.scale)
 
     @no_annotations
     def hessian(self, m_dot, options={}):
@@ -92,18 +336,7 @@ class ReducedFunctional(object):
             OverloadedType: The action of the Hessian in the direction m_dot.
                 Should be an instance of the same type as the control.
         """
-        # Call callback
-        values = [c.tape_value() for c in self.controls]
-        self.hessian_cb_pre(self.controls.delist(values))
-
-        r = compute_hessian(self.functional, self.controls, m_dot, options=options, tape=self.tape)
-
-        # Call callback
-        self.hessian_cb_post(self.functional.block_variable.checkpoint,
-                             self.controls.delist(r),
-                             self.controls.delist(values))
-
-        return self.controls.delist(r)
+        return self.hess_action(m_dot, self.scale)
 
     @no_annotations
     def __call__(self, values):
@@ -120,40 +353,8 @@ class ReducedFunctional(object):
                 of :class:`AdjFloat`.
 
         """
-        values = Enlist(values)
-        if len(values) != len(self.controls):
-            raise ValueError("values should be a list of same length as controls.")
-
-        # Call callback.
-        self.eval_cb_pre(self.controls.delist(values))
-
-        for i, value in enumerate(values):
-            self.controls[i].update(value)
-
-        self.tape.reset_blocks()
-        blocks = self.tape.get_blocks()
-        with self.marked_controls():
-            with stop_annotating():
-                for i in self.tape._bar("Evaluating functional").iter(
-                    range(len(blocks))
-                ):
-                    blocks[i].recompute()
-
-        func_value = self.scale * self.functional.block_variable.checkpoint
-
-        # Call callback
-        self.eval_cb_post(func_value, self.controls.delist(values))
-
-        return func_value
-
-    def optimize_tape(self):
-        self.tape.optimize(
-            controls=self.controls,
-            functionals=[self.functional]
-        )
-
-    def marked_controls(self):
-        return marked_controls(self)
+        val = super().__call__(values)
+        return val * self.scale
 
 
 class marked_controls(object):

--- a/pyadjoint/reduced_functional_numpy.py
+++ b/pyadjoint/reduced_functional_numpy.py
@@ -1,6 +1,5 @@
-from __future__ import print_function
-from .reduced_functional import ReducedFunctional
-from .tape import no_annotations, get_working_tape
+from .reduced_functional import ReducedFunction, ReducedFunctional
+from .tape import no_annotations
 from .enlisting import Enlist
 from .control import Control
 from .adjfloat import AdjFloat
@@ -8,7 +7,143 @@ from .adjfloat import AdjFloat
 import numpy
 
 
-class ReducedFunctionalNumPy(ReducedFunctional):
+class ReducedFunctionNumPy(ReducedFunction):
+    """This class implements the reduced function for given function and
+    controls based on NumPy data structures.
+
+    This "NumPy version" of the ReducedFunction is created from
+    an existing ReducedFunction object:
+    rf_np = ReducedFunctionNumPy(rf = rf)
+    """
+
+    def __init__(self, reduced_function):
+        if not isinstance(reduced_function, ReducedFunction):
+            raise TypeError("reduced_function should be a ReducedFunction")
+
+        self.rf = reduced_function
+        self.output_controls = [Control(bv.output) for bv in self.outputs]
+
+    def __getattr__(self, item):
+        return getattr(self.rf, item)
+
+    def get_rf_input(self, controls, m_array):
+        """Converts a array to a list of OverloadedTypes using the given controls."""
+        m_copies = [control.copy_data() for control in controls]
+        return self.set_local_controls(controls, m_array, m_copies)
+
+    def set_local(self, m_array, m):
+        return self.set_local_controls(self.controls, m_array, m)
+
+    def set_local_controls(self, controls, m_array, m):
+        """Use the given numpy array to set the values of the given list of control
+        values."""
+        offset = 0
+        for i, control in enumerate(controls):
+            m[i], offset = control.assign_numpy(m[i], m_array, offset)
+        return m
+
+    def get_global(self, m):
+        """Converts the given list of control values m to a single numpy array."""
+        m_global = []
+        for i, v in enumerate(Enlist(m)):
+            if isinstance(v, Control):
+                # TODO: Consider if you want this design.
+                m_global += v.fetch_numpy(v.control)
+            elif hasattr(v, "_ad_to_list"):
+                m_global += v._ad_to_list(v)
+            else:
+                m_global += self.controls[i].control._ad_to_list(v)
+        return numpy.array(m_global, dtype="d")
+
+    def get_outputs_array(self, values):
+        m_global = []
+        values = Enlist(values)
+        for i, bv in enumerate(self.outputs):
+            if values[i] is not None:
+                m_global += bv.output._ad_to_list(values[i])
+            else:
+                m_global += [0] * bv.output._ad_dim()
+        return numpy.array(m_global, dtype="d")
+
+    @no_annotations
+    def __call__(self, m_array):
+        """An implementation of the reduced function evaluation
+            that accepts the control values as an array of scalars.
+
+        """
+        m = self.get_rf_input(self.controls, m_array)
+        output = self.rf(m)
+        return self.get_outputs_array(output)
+
+    @no_annotations
+    def jac_action(self, h_array):
+        """An implementation of the reduced function jac_action evaluation
+        that accepts the controls as an array of scalars.
+        """
+
+        h = self.get_rf_input(self.controls, h_array)
+        dJdm_h = self.rf.jac_action(h)
+        return self.get_outputs_array(dJdm_h)
+
+    @no_annotations
+    def adj_jac_action(self, v_array):
+        """An implementation of the reduced functional adjoint evaluation
+        that returns the derivatives as an array of scalars.
+        """
+
+        v = self.get_rf_input(self.output_controls, v_array)
+        v_dJdm = self.rf.adj_jac_action(v)
+        v_dJdm = Enlist(v_dJdm)
+
+        m_global = []
+        for i, control in enumerate(self.controls):
+            # This is a little ugly, but we need to go through the control to get to the OverloadedType.
+            # There is no guarantee that v_dJdm[i] is an OverloadedType and not a backend type.
+            m_global += control.fetch_numpy(v_dJdm[i])
+
+        return numpy.array(m_global, dtype="d")
+
+    @no_annotations
+    def hess_action(self, h_array, v_array):
+        """An implementation of the reduced function hessian action evaluation
+        that accepts the controls as an array of scalars. If m_array is None,
+        the Hessian action at the latest forward run is returned."""
+        # Calling derivative is needed, see i.e. examples/stokes-shape-opt
+        h = self.get_rf_input(self.controls, h_array)
+        v = self.get_rf_input(self.output_controls, v_array)
+        self.rf.adj_jac_action(v)
+
+        v_hessian_h = self.rf.hess_action(h, v)
+        v_hessian_h = Enlist(v_hessian_h)
+
+        m_global = []
+        for i, control in enumerate(self.controls):
+            # This is a little ugly, but we need to go through the control to get to the OverloadedType.
+            # There is no guarantee that dJdm[i] is an OverloadedType and not a backend type.
+            m_global += control.fetch_numpy(v_hessian_h[i])
+
+        self.rf.tape.reset_variables()
+
+        return numpy.array(m_global, dtype="d")
+
+    def obj_to_array(self, obj):
+        return self.get_global(obj)
+
+    def get_controls(self, controls=None):
+        if controls is None:
+            controls = self.controls
+        m = [p.tape_value() for p in controls]
+        return self.obj_to_array(m)
+
+    def set_controls(self, m_array):
+        m = [p.tape_value() for p in self.controls]
+        m = self.set_local_controls(self.controls, m_array, m)
+        for control, m_i in zip(self.controls, m):
+            control.update(m_i)
+        return m
+
+
+class ReducedFunctionalNumPy(ReducedFunctionNumPy):
     """This class implements the reduced functional for given functional and
     controls based on numpy data structures.
 
@@ -23,36 +158,6 @@ class ReducedFunctionalNumPy(ReducedFunctional):
                                            controls=controls,
                                            tape=tape)
         self.rf = functional
-
-    def __getattr__(self, item):
-        return getattr(self.rf, item)
-
-    def __call__(self, m_array):
-        """An implementation of the reduced functional evaluation
-            that accepts the control values as an array of scalars
-
-        """
-        m_copies = [control.copy_data() for control in self.controls]
-        return self.rf.__call__(self.set_local(m_copies, m_array))
-
-    def set_local(self, m, m_array):
-        offset = 0
-        for i, control in enumerate(self.controls):
-            m[i], offset = control.assign_numpy(m[i], m_array, offset)
-
-        return m
-
-    def get_global(self, m):
-        m_global = []
-        for i, v in enumerate(Enlist(m)):
-            if isinstance(v, Control):
-                # TODO: Consider if you want this design.
-                m_global += v.fetch_numpy(v.control)
-            elif hasattr(v, "_ad_to_list"):
-                m_global += v._ad_to_list(v)
-            else:
-                m_global += self.controls[i].control._ad_to_list(v)
-        return numpy.array(m_global, dtype="d")
 
     @no_annotations
     def derivative(self, m_array=None, forget=True, project=False):
@@ -84,9 +189,9 @@ class ReducedFunctionalNumPy(ReducedFunctional):
             that accepts the controls as an array of scalars. If m_array is None,
             the Hessian action at the latest forward run is returned. """
         # Calling derivative is needed, see i.e. examples/stokes-shape-opt
-        self.derivative()
-        m_copies = [control.copy_data() for control in self.controls]
-        Hm = self.rf.hessian(self.set_local(m_copies, m_dot_array))
+        self.rf.derivative()
+        h = self.get_rf_input(self.controls, m_dot_array)
+        Hm = self.rf.hessian(h)
         Hm = Enlist(Hm)
 
         m_global = []
@@ -95,24 +200,9 @@ class ReducedFunctionalNumPy(ReducedFunctional):
             # There is no guarantee that dJdm[i] is an OverloadedType and not a backend type.
             m_global += control.fetch_numpy(Hm[i])
 
-        tape = get_working_tape()
-        tape.reset_variables()
+        self.rf.tape.reset_variables()
 
         return numpy.array(m_global, dtype="d")
-
-    def obj_to_array(self, obj):
-        return self.get_global(obj)
-
-    def get_controls(self):
-        m = [p.tape_value() for p in self.controls]
-        return self.obj_to_array(m)
-
-    def set_controls(self, array):
-        m = [p.tape_value() for p in self.controls]
-        m = self.set_local(m, array)
-        for control, m_i in zip(self.controls, m):
-            control.update(m_i)
-        return m
 
 
 def set_local(coeffs, m_array):

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -185,6 +185,12 @@ class Tape(object):
                 tags.append(block.tag)
         return tags
 
+    def recompute(self, inputs=None, outputs=None):
+        for i in self._bar("Recomputing").iter(
+            range(len(self._blocks))
+        ):
+            self._blocks[i].recompute()
+
     def evaluate_adj(self, last_block=0, markings=False):
         for i in self._bar("Evaluating adjoint").iter(
             range(len(self._blocks) - 1, last_block - 1, -1)

--- a/pyadjoint/verification.py
+++ b/pyadjoint/verification.py
@@ -2,90 +2,76 @@ import logging
 
 from .enlisting import Enlist
 from .tape import stop_annotating
+from .overloaded_type import create_overloaded_objects
 
 
-def taylor_test(J, m, h, dJdm=None, Hm=0):
-    """Run a taylor test on the functional J around point m in direction h.
+def taylor_test(J, m, h, dJdm=None, Hm=0.0, v=None, epsilons=None):
+    """Run a taylor test on the function J around point m in direction h.
 
-    Given a functional J, a point in control space m, and a direction in
+    Given a functional/function J, a point in control space m, and a direction in
     control space h, the function computes the taylor remainders and
     returns the convergence rate.
 
+    This function calls :func:`taylor_to_dict` and returns the minimum
+    convergence rate of the results from the 2nd order test. Note that the
+    argument Hm=0 by default, which means the Hessian will not be automatically
+    calculated by default.
+
+    Also, note that if you do not supply v, then the TLM action will be used
+    to compute the derivative, but if you do supply v, the adjoint action
+    will be used.
+
     Args:
-        J (reduced_functional.ReducedFunctional): The functional to evaluate the taylor remainders of.
-            Must be an instance of :class:`ReducedFunctional`, or something with a similar
-            interface.
-        m (overloaded_type.OverloadedType): The expansion points in control space. Must be of same type as the
-            control.
-        h (overloaded_type.OverloadedType): The direction of perturbations. Must be of same type as
-            the control.
+        See :func:`taylor_to_dict`.
 
     Returns:
         float: The smallest computed convergence rate of the tested perturbations.
 
     """
-    with stop_annotating():
-        hs = Enlist(h)
-        ms = Enlist(m)
 
-        if len(hs) != len(ms):
-            raise ValueError(
-                "%d perturbations are given but only %d expansion points are provided" % (len(hs), len(ms)))
+    error_dict = taylor_to_dict(J, m, h, dJdm=dJdm, Hm=Hm, v=v, epsilons=epsilons)
 
-        Jm = J(m)
-        if dJdm is None:
-            ds = Enlist(J.derivative())
-            if len(ds) != len(ms):
-                raise ValueError(
-                    "The derivative of J depends on %d variables but only %d expansion points are given" % (
-                        len(ds), len(ms)))
-            dJdm = sum(hi._ad_dot(di) for hi, di in zip(hs, ds))
+    residuals = error_dict["R2"]["Residual"]
+    rates = error_dict["R2"]["Rate"]
 
-        def perturbe(eps):
-            ret = [mi._ad_add(hi._ad_mul(eps)) for mi, hi in zip(ms, hs)]
-            return ms.delist(ret)
-
-        print("Running Taylor test")
-        residuals = []
-        epsilons = [0.01 / 2 ** i for i in range(4)]
-        for eps in epsilons:
-            Jp = J(perturbe(eps))
-            res = abs(Jp - Jm - eps * dJdm - 0.5 * eps ** 2 * Hm)
-            residuals.append(res)
-
-        if min(residuals) < 1E-15:
-            logging.warning("The taylor remainder is close to machine precision.")
-        print("Computed residuals: {}".format(residuals))
-    return min(convergence_rates(residuals, epsilons))
+    if min(residuals) < 1e-15:
+        logging.warning("The taylor remainder is close to machine precision.")
+    print("Computed residuals: {}".format(residuals))
+    print("Computed convergence rates: {}".format(rates))
+    return min(rates)
 
 
-def convergence_rates(E_values, eps_values, show=True):
-    from numpy import log
-    r = []
-    for i in range(1, len(eps_values)):
-        r.append(log(E_values[i] / E_values[i - 1])
-                 / log(eps_values[i] / eps_values[i - 1]))
-    if show:
-        print("Computed convergence rates: {}".format(r))
-    return r
-
-
-def taylor_to_dict(J, m, h):
-    """Run a 0th, 1st and second order taylor test on the functional J
+def taylor_to_dict(J, m, h, dJdm=None, Hm=None, v=None, epsilons=None, show=False):
+    """Run a 0th, 1st and 2nd order taylor test on the function J
       around point m in direction h.
 
-    Given a functional J, a point in control space m, and a direction in
-    control space h, the function computes the taylor remainders and
+    Given a function J, a point in control space m, and a direction in
+    control space h, `taylor_to_dict` computes the taylor remainders and
     returns the convergence rate in a dictionary.
 
     Args:
-        J (reduced_functional.ReducedFunctional): The functional to evaluate the taylor remainders of.
-            Must be an instance of :class:`ReducedFunctional`, or something with a similar
-            interface.
-        m (overloaded_type.OverloadedType): The expansion points in control space. Must be of same type as the
-            control.
-        h (overloaded_type.OverloadedType): The direction of perturbations. Must be of same type as
-            the control.
+        J (reduced_function.ReducedFunction): The function to
+            evaluate the taylor remainders of. Must be an instance of
+            :class:`ReducedFunction`, or something with a similar interface.
+        m (overloaded_type.OverloadedType): The expansion points in control
+            space. Must be of same type as the control.
+        h (overloaded_type.OverloadedType): The direction of perturbations. Must
+            be of same type as the control.
+
+    Optional:
+        dJdm: The derivative of J with respect to m in the direction h. If v is
+            given or if J is a functional (in which case v=1 automatically),
+            then this should be a float formed by dotting J.adj_jac_action(v)
+            with h. If v is not given, this should be the same type as the
+            output of J. This will be automatically calculated if it is None.
+        Hm: The second derivative of J with respect to m. The Hessian will be
+            ignored if this is 0, but it will be automatically calculated if
+            this is None. Calculating the Hessian requires v. Hm is calculated
+            by dotting h with J.hess_action(h, v).
+        v: This is an adjoint direction. Must be of same type as the the output
+            of J. If it is given, then dJdm is calculated using the adjoint
+            Jacobian action instead of the forward Jacobian action. If J is not
+            a float, it will be dotted with v to convert it to a float.
 
     Returns:
         dict: The perturbation sizes, residuals and rates of the tests.
@@ -103,50 +89,174 @@ def taylor_to_dict(J, m, h):
 
     """
     with stop_annotating():
-        hs = Enlist(h)
-        ms = Enlist(m)
+        hs_orig = Enlist(h)
+        hs = create_overloaded_objects(hs_orig)
+        ms = create_overloaded_objects(m)
 
         if len(hs) != len(ms):
-            raise ValueError("{0:d} perturbations are given but only {1:d} expansion points are provided"
-                             .format(len(hs), len(ms)))
+            raise ValueError(
+                "{0:d} perturbations are given but only {1:d} expansion points are provided".format(
+                    len(hs), len(ms)
+                )
+            )
 
-        Jm = J(m)
-        print("Computing derivative")
-        ds = Enlist(J.derivative())
-        if len(ds) != len(ms):
-            raise ValueError("The derivative of J depends on {0:d} variables"
-                             .format(len(ds))
-                             + "but only {0:d} expansion points are given".
-                             format(len(ms)))
-        dJdm = sum(hi._ad_dot(di) for hi, di in zip(hs, ds))
-
-        print("Computing Hessian")
-
-        Hm = Enlist(J.hessian(hs))
-        Hmh = sum(hi._ad_dot(hmi) for hi, hmi in zip(hs, Hm))
+        Jm, dJdm, Hm = _get_derivatives(J, m, h, dJdm, Hm, v)
 
         def perturbe(eps):
             ret = [mi._ad_add(hi._ad_mul(eps)) for mi, hi in zip(ms, hs)]
-            return ms.delist(ret)
+            return hs_orig.delist(ret)
 
         print("Running Taylor test")
-        error_dict = {"eps": None, "R0": {"Residual": [], "Rate": None},
-                      "R1": {"Residual": [], "Rate": None},
-                      "R2": {"Residual": [], "Rate": None}}
+        error_dict = {
+            "R0": {"Residual": [], "Rate": None},
+            "R1": {"Residual": [], "Rate": None},
+            "R2": {"Residual": [], "Rate": None},
+        }
 
-        epsilons = [0.01 / 2**i for i in range(4)]
-        error_dict["eps"] = epsilons
+        if epsilons is None:
+            epsilons = [0.01 / 2 ** i for i in range(4)]
+        epsilons = Enlist(epsilons)
+
+        Jps = []
         for eps in epsilons:
             Jp = J(perturbe(eps))
-            error_dict["R0"]["Residual"].append(abs(Jp - Jm))
-            error_dict["R1"]["Residual"].append(abs(Jp - Jm - eps * dJdm))
-            error_dict["R2"]["Residual"].append(abs(Jp - Jm - eps * dJdm - 0.5 * eps**2 * Hmh))
+            Jp, zeroth_order, first_order, second_order = calculate_residuals(
+                Jm, dJdm, Hm, Jp, eps, v=v
+            )
+
+            error_dict["R0"]["Residual"].append(zeroth_order)
+            error_dict["R1"]["Residual"].append(first_order)
+            error_dict["R2"]["Residual"].append(second_order)
+            Jps.append(Jp)
 
         for key in error_dict.keys():
-            if key != "eps":
-                error_dict[key]["Rate"] = convergence_rates(error_dict[key]
-                                                            ["Residual"][:],
-                                                            error_dict["eps"],
-                                                            show=False)
+            error_dict[key]["Rate"] = convergence_rates(
+                error_dict[key]["Residual"], epsilons, show=show
+            )
+        error_dict["eps"] = epsilons
+        error_dict["Jm"] = Jm
+        error_dict["dJdm"] = dJdm
+        error_dict["Jps"] = Jps
+
+    # Reset block variable values back to original value of m before returning.
     J(m)
     return error_dict
+
+
+def _get_derivatives(J, m, h, dJdm=None, Hm=None, v=None):
+    hs = create_overloaded_objects(h)
+    ms = create_overloaded_objects(m)
+
+    Jm = J(m)
+    if v is not None:
+        Jm = create_overloaded_objects(Jm)
+        Jm = sum(
+            Jm_i._ad_dot(Jm_i._ad_convert_type(v_i)) for Jm_i, v_i in zip(Jm, Enlist(v))
+        )
+
+    if dJdm is None:
+        print("Computing derivative")
+        if isinstance(Jm, (float, int)) and hasattr(J, "derivative"):
+            ds = Enlist(J.derivative())
+            if len(ds) != len(ms):
+                raise ValueError(
+                    "The derivative of J depends on %d variables but only %d expansion points are given"
+                    % (len(ds), len(ms))
+                )
+            if v is not None:
+                ds = create_overloaded_objects(ds)
+                ds = [di._ad_mul(v) for di in ds]
+            dJdm = sum(hi._ad_dot(di) for hi, di in zip(hs, ds))
+        else:
+            if v is None:
+                dJdm = create_overloaded_objects(J.jac_action(h))
+            else:
+                ds = Enlist(J.adj_jac_action(v))
+                if len(ds) != len(ms):
+                    raise ValueError(
+                        "The derivative of J depends on %d variables but only %d expansion points are given"
+                        % (len(ds), len(ms))
+                    )
+                dJdm = sum(hi._ad_dot(di) for hi, di in zip(hs, ds))
+
+    if Hm is None:
+        if isinstance(Jm, (float, int)) and hasattr(J, "derivative"):
+            print("Computing Hessian")
+            Hms = Enlist(J.hessian(hs))
+        else:
+            if v is None:
+                raise ValueError("v must be specified to compute Hessian")
+            print("Computing Hessian")
+            Hms = J.hess_action(hs, v)
+        Hm = sum(hi._ad_dot(hmi) for hi, hmi in zip(hs, Hms))
+
+    return Jm, dJdm, Hm
+
+
+def calculate_residuals(Jm, dJdm, Hm, Jp, eps, v=None):
+    def mag(res):
+        return sum(ri._ad_dot(ri) for ri in res) ** 0.5
+
+    if v is not None:
+        Jp = create_overloaded_objects(Jp)
+        Jp = sum(
+            Jp_i._ad_dot(Jp_i._ad_convert_type(v_i)) for Jp_i, v_i in zip(Jp, Enlist(v))
+        )
+
+    if (
+        isinstance(Jp, (float, int))
+        and isinstance(Jm, (float, int))
+        and isinstance(dJdm, (float, int))
+        and isinstance(Hm, (float, int))
+    ):
+        res = Jp - Jm
+        zeroth_order = abs(res)
+
+        res -= eps * dJdm
+        first_order = abs(res)
+
+        res -= 0.5 * eps ** 2 * Hm
+        second_order = abs(res)
+    else:
+        res = [None] * len(Jp)
+
+        Jm = create_overloaded_objects(Jm)
+        Jp = create_overloaded_objects(Jp)
+        for i in range(len(Jp)):
+            res[i] = Jp[i]._ad_add(Jm[i]._ad_mul(-1.0))
+        zeroth_order = mag(res)
+
+        if dJdm:
+            dJdm = create_overloaded_objects(dJdm)
+            for i in range(len(Jp)):
+                res[i] = res[i]._ad_add(dJdm[i]._ad_mul(-eps))
+            first_order = mag(res)
+        else:
+            first_order = zeroth_order
+
+        if Hm:
+            Hm = create_overloaded_objects(Hm)
+            for i in range(len(Jp)):
+                res[i] = res[i]._ad_add(Hm[i]._ad_mul(-0.5 * eps ** 2))
+            second_order = mag(res)
+        else:
+            second_order = first_order
+
+    return Jp, zeroth_order, first_order, second_order
+
+
+def convergence_rates(E_values, eps_values, show=True):
+    from numpy import log, inf, nan
+
+    r = []
+    for i in range(1, len(eps_values)):
+        if E_values[i - 1] == 0:
+            r.append(nan if E_values[i] == 0 else inf)
+        else:
+            r.append(
+                log(E_values[i] / E_values[i - 1])
+                / log(eps_values[i] / eps_values[i - 1])
+            )
+    if show:
+        print("Computed convergence rates: {}".format(r))
+    return r

--- a/tests/pyadjoint/test_reduced_function.py
+++ b/tests/pyadjoint/test_reduced_function.py
@@ -1,0 +1,57 @@
+from pyadjoint import *
+import numpy as np
+
+
+def test_reduced_function():
+    def get_y(x):
+        """Adjoint Jacobian:
+            [1, x[1], 0]
+            [1, x[0], 2*x[1]]
+
+            Hessian with shape (dx, dx, dy):
+
+            Hessian[0]:
+                [0, 0, 0]
+                [0, 1, 0]
+
+            Hessian[1]:
+                [0, 1, 0]
+                [0, 0, 2]
+
+            [v0, v1, v2] * Hessian:
+                [ [0]
+                  [v1]],
+                [ [v1]
+                  [2*v2]]
+
+            [v0, v1, v2] * Hessian * [h0, h1]:
+                [ v1 * h1, v1 * h0 + 2 * v2 * h1]
+        """
+
+        return [
+            x[0] + x[1],
+            x[0] * x[1],
+            x[1] * x[1],
+        ]
+
+    x = [AdjFloat(3.0), AdjFloat(5.0)]
+    y = get_y(x)
+
+    with stop_annotating():
+        controls = [Control(xi) for xi in x]
+        rf = ReducedFunction(y, controls)
+
+        new_x = [2.0, 3.0]
+        assert rf(new_x) == get_y(new_x)
+        assert rf(x) == y
+
+        adj_input = [1.0, 2.0, 3.0]
+        adj_output = [11, 37]
+        assert rf.adj_jac_action(adj_input) == adj_output
+
+        tml_input = [-1.0, -2.0]
+        tml_output = [-3.0, -6.0, -12.0]
+        assert rf.jac_action(tml_input)
+
+        hess_output = [-4, -14]
+        assert rf.hess_action(tml_input, adj_input) == hess_output

--- a/tests/pyadjoint/test_reduced_function.py
+++ b/tests/pyadjoint/test_reduced_function.py
@@ -1,57 +1,102 @@
 from pyadjoint import *
 import numpy as np
 
+def example1_get_y(x):
+    """Adjoint Jacobian:
+        [1, x1, x1**2]
+        [1, x0, 2*x0*x1]
+
+        Hessian with shape (dx, dx, dy):
+
+        Hessian[0]:
+            [0, 0, 0]
+            [0, 1, 2*x1]
+
+        Hessian[1]:
+            [0, 1, 2*x1]
+            [0, 0, 2*x0]
+
+        [v0, v1, v2] * Hessian:
+            [ [0]
+              [v1 + 2*v2*x1]],
+            [ [v1 + 2*v2*x1]]
+              [2*v2*x0]]
+
+        [v0, v1, v2] * Hessian * [h0, h1]:
+            [ (v1 + 2*v2*x1) * h1, (v1 + 2*v2*x1) * h0 + 2*v2*x0*h1]
+    """
+
+    return [
+        x[0] + x[1],
+        x[0] * x[1],
+        x[1] * x[1] * x[0],
+    ]
 
 def test_reduced_function():
-    def get_y(x):
-        """Adjoint Jacobian:
-            [1, x[1], 0]
-            [1, x[0], 2*x[1]]
-
-            Hessian with shape (dx, dx, dy):
-
-            Hessian[0]:
-                [0, 0, 0]
-                [0, 1, 0]
-
-            Hessian[1]:
-                [0, 1, 0]
-                [0, 0, 2]
-
-            [v0, v1, v2] * Hessian:
-                [ [0]
-                  [v1]],
-                [ [v1]
-                  [2*v2]]
-
-            [v0, v1, v2] * Hessian * [h0, h1]:
-                [ v1 * h1, v1 * h0 + 2 * v2 * h1]
-        """
-
-        return [
-            x[0] + x[1],
-            x[0] * x[1],
-            x[1] * x[1],
-        ]
-
     x = [AdjFloat(3.0), AdjFloat(5.0)]
-    y = get_y(x)
+    y = example1_get_y(x)
 
     with stop_annotating():
         controls = [Control(xi) for xi in x]
         rf = ReducedFunction(y, controls)
 
         new_x = [2.0, 3.0]
-        assert rf(new_x) == get_y(new_x)
+        assert rf(new_x) == example1_get_y(new_x)
         assert rf(x) == y
 
         adj_input = [1.0, 2.0, 3.0]
-        adj_output = [11, 37]
+        adj_output = [86, 97]
         assert rf.adj_jac_action(adj_input) == adj_output
 
         tml_input = [-1.0, -2.0]
-        tml_output = [-3.0, -6.0, -12.0]
-        assert rf.jac_action(tml_input)
+        tml_output = [-3.0, -11.0, -85.0]
+        assert rf.jac_action(tml_input) == tml_output
 
-        hess_output = [-4, -14]
+        hess_output = [-64, -68]
         assert rf.hess_action(tml_input, adj_input) == hess_output
+
+def test_taylor_test():
+    x = [AdjFloat(3.0), AdjFloat(5.0)]
+    y = example1_get_y(x)
+
+    with stop_annotating():
+        controls = [Control(xi) for xi in x]
+        rf = ReducedFunction(y, controls)
+
+        v = [1.0, 2.0, 3.0]
+        h = [-1.0, -2.0]
+
+        jac = rf.jac_action(h)
+        adj_jac = rf.adj_jac_action(v)
+        hess = rf.hess_action(h, v)
+
+        rate_keys = ["R0", "R1", "R2"]
+        results = taylor_to_dict(rf, x, h, v=v)
+        for order, k in enumerate(rate_keys):
+            assert min(results[k]["Rate"]) > order + 0.9, results[k]
+
+        # Call with or without v to separately test adjoint and TLM.
+        assert taylor_test(rf, x, h) > 1.9
+        assert taylor_test(rf, x, h, v=v) > 1.9
+
+        # Call with dJdm = 0. to skip derivative calculations.
+        assert taylor_test(rf, x, h, dJdm=0, v=v) > 0.9
+        assert taylor_test(rf, x, h, dJdm=0) > 0.9
+
+        # Call with correct dJdm to skip derivative calculations.
+        dJdm = jac
+        assert taylor_test(rf, x, h, dJdm=dJdm) > 1.9
+
+        dJdm = sum(vi * jac_i for vi, jac_i in zip(v, jac))
+        assert taylor_test(rf, x, h, dJdm=dJdm, v=v) > 1.9
+
+        dJdm = sum(hi * adj_i for hi, adj_i in zip(h, adj_jac))
+        assert taylor_test(rf, x, h, dJdm=dJdm, v=v) > 1.9
+
+        # Call with Hm = None to include Hessian calculations.
+        assert taylor_test(rf, x, h, v=v, Hm=None) > 2.9
+
+        # Call with correct Hm to skip Hessian calculations.
+        Hm = sum(hi * hess_i for hi, hess_i in zip(h, hess))
+        assert taylor_test(rf, x, h, Hm=Hm, v=v) > 2.9
+


### PR DESCRIPTION
This MR adds the `ReducedFunction` and `ReducedFunctionNumPy` classes, and a new driver `compute_jacobian_action` for the TLM calculations.

`ReducedFunctional` is now a subclass of `ReducedFunction`, and `ReducedFunctionalNumPy` is now a subclass of `ReducedFunctionNumPy`.

I updated `taylor_to_dict` to work with `ReducedFunction`. To avoid duplicating code, I changed `taylor_test` to call `taylor_to_dict` while still maintaining the same interface.

Tests for these changes are in `pyadjoint/test_reduced_function.py`.