### PR TITLE
Replace assign with interpolate

### DIFF
--- a/dolfin_adjoint_common/blocks/function.py
+++ b/dolfin_adjoint_common/blocks/function.py
@@ -56,16 +56,12 @@ class FunctionAssignBlock(Block):
             # Linear combination
             expr, adj_input_func = prepared
             adj_output = self.backend.Function(adj_input_func.function_space())
-            if block_variable.saved_output.ufl_shape == adj_input_func.ufl_shape:
+            if not isinstance(block_variable.output, self.backend.Constant):
                 diff_expr = ufl.algorithms.expand_derivatives(
                     ufl.derivative(expr, block_variable.saved_output, adj_input_func)
                 )
                 adj_output.assign(diff_expr)
             else:
-                # Assume current variable is scalar constant.
-                # This assumption might be wrong for firedrake.
-                assert isinstance(block_variable.output, self.backend.Constant)
-
                 diff_expr = ufl.algorithms.expand_derivatives(
                     ufl.derivative(expr, block_variable.saved_output, self.backend.Constant(1.))
                 )

--- a/dolfin_adjoint_common/blocks/function.py
+++ b/dolfin_adjoint_common/blocks/function.py
@@ -13,7 +13,7 @@ class FunctionAssignBlock(Block):
             other = AdjFloat(other)
         if isinstance(other, OverloadedType):
             self.add_dependency(other, no_duplicates=True)
-        elif not(isinstance(other, float) or isinstance(other, int)):
+        elif not (isinstance(other, float) or isinstance(other, int)):
             # Assume that this is a point-wise evaluated UFL expression (firedrake only)
             for op in traverse_unique_terminals(other):
                 if isinstance(op, OverloadedType):
@@ -138,7 +138,7 @@ class FunctionAssignBlock(Block):
         if self.expr is None:
             prepared = inputs[0]
         output = self.backend.Function(block_variable.output.function_space())
-        self.backend.Function.assign(output, prepared)
+        output.assign(prepared)
         return output
 
     def __str__(self):

--- a/tests/firedrake_adjoint/test_assignment.py
+++ b/tests/firedrake_adjoint/test_assignment.py
@@ -73,7 +73,7 @@ def test_assign_tlm():
     assert taylor_test(rf, f, h, dJdm=J.block_variable.tlm_value) > 1.9
 
 
-def test_assign_tlm_wit_constant():
+def test_assign_tlm_with_constant():
     mesh = IntervalMesh(10, 0, 1)
     V = FunctionSpace(mesh, "CG", 1)
 
@@ -151,7 +151,6 @@ def test_assign_with_constant():
 
     u.assign(c*f+d**3)
 
-    # J = c**2/3 + cd**3 + d**6
     J = assemble(u ** 2 * dx)
 
     rf = ReducedFunctional(J, Control(c))

--- a/tests/firedrake_adjoint/test_assignment.py
+++ b/tests/firedrake_adjoint/test_assignment.py
@@ -83,7 +83,7 @@ def test_assign_tlm_with_constant():
     c = Constant(5.0)
 
     u = Function(V)
-    u.assign(c * f ** 2)
+    u.interpolate(c * f**2)
 
     c.block_variable.tlm_value = Constant(0.3)
     tape = get_working_tape()
@@ -129,7 +129,7 @@ def test_assign_nonlincom():
     g = interpolate(sin(x[0]), V)
     u = Function(V)
 
-    u.assign(f*g)
+    u.interpolate(f*g)
 
     J = assemble(u ** 2 * dx)
     rf = ReducedFunctional(J, Control(f))
@@ -181,7 +181,7 @@ def test_assign_nonlin_changing():
 
     u = Function(V)
 
-    u.assign(f*sol*g)
+    u.interpolate(f*sol*g)
 
     J = assemble(u ** 2 * dx)
     rf = ReducedFunctional(J, control)


### PR DESCRIPTION
In https://github.com/firedrakeproject/firedrake/pull/2562 I am restricting the functionality of `Function.assign` such that it only works for weighted sums (it makes more sense mathematically and is also faster). This causes a few breakages in pyadjoint so here I'm just replacing instances where `assign` might be invalid with `interpolate` which will always work.