### PR TITLE
Adjoint of vector-valued reduced functionals

### DIFF
--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -144,7 +144,7 @@ class ReducedFunctional(object):
                     blocks[i].recompute()
 
         # ReducedFunctional can result in a scalar or an assembled 1-form
-        func_value = self.functional.block_variable.checkpoint
+        func_value = self.functional.block_variable.saved_output
         # Scale the underlying functional value
         func_value *= self.scale
 

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -61,7 +61,10 @@ class ReducedFunctional(object):
         values = [c.tape_value() for c in self.controls]
         self.derivative_cb_pre(self.controls.delist(values))
 
-        adj_value = self.scale * adj_input
+        # Scale adjoint input
+        with stop_annotating():
+            adj_value = self.scale * adj_input
+
         derivatives = compute_gradient(self.functional,
                                        self.controls,
                                        options=options,

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -140,13 +140,10 @@ class ReducedFunctional(object):
                 ):
                     blocks[i].recompute()
 
-        # func_value = self.scale * self.functional.block_variable.checkpoint
+        # ReducedFunctional can result in a scalar or an assembled 1-form
         func_value = self.functional.block_variable.checkpoint
-        if isinstance(func_value, float):
-            func_value = self.scale * self.functional.block_variable.checkpoint
-        else:
-            # ReducedFunctional results in an assembled 1-form
-            func_value.vector()._scale(self.scale)
+        # Scale the underlying functional value
+        func_value *= self.scale
 
         # Call callback
         self.eval_cb_post(func_value, self.controls.delist(values))

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -16,11 +16,6 @@ def get_working_tape():
     return _working_tape
 
 
-def set_working_tape(tape):
-    global _working_tape
-    _working_tape = tape
-
-
 def pause_annotation():
     global _stop_annotating
     _stop_annotating += 1
@@ -30,6 +25,41 @@ def continue_annotation():
     global _stop_annotating
     _stop_annotating -= 1
     return _stop_annotating <= 0
+
+
+class set_working_tape(object):
+    """A context manager whithin which a new tape is set as the working tape.
+       This context manager can also be used in an imperative manner.
+
+       Example usage:
+
+        1) Set a new tape as the working tape:
+            ```
+            set_working_tape(Tape())
+            ```
+
+        2) Set a local tape within a context manager:
+            ```
+            with set_working_tape() as tape:
+                ...
+            ```
+    """
+    def __init__(self, tape=None, **tape_kwargs):
+        # Get working tape
+        global _working_tape
+        # Store current tape
+        self.old_tape = _working_tape
+        # Set new tape
+        self.tape = tape or Tape(**tape_kwargs)
+        _working_tape = self.tape
+
+    def __enter__(self):
+        return self.tape
+
+    def __exit__(self, *args):
+        # Re-establish the original tape
+        global _working_tape
+        _working_tape = self.old_tape
 
 
 class stop_annotating(object):

--- a/tests/pyadjoint/test_overload_function.py
+++ b/tests/pyadjoint/test_overload_function.py
@@ -1,6 +1,6 @@
 from pyadjoint.overloaded_function import overload_function, overloaded_function
 from pyadjoint import Block, AdjFloat, ReducedFunctional, Control
-from pyadjoint.tape import no_annotations, Tape, set_working_tape
+from pyadjoint.tape import no_annotations, Tape, set_working_tape, get_working_tape
 import numpy as np
 
 
@@ -57,3 +57,22 @@ def test_overload_function():
 
     Jhat = ReducedFunctional(q, Control(z))
     assert(Jhat.derivative() == -np.sin(t * np.sin(z)) * t * np.cos(z))
+
+
+def test_tape():
+    tape = Tape()
+    set_working_tape(tape)
+    assert get_working_tape() == tape
+
+    get_blocks_type = lambda t: [type(b) for b in t.get_blocks()]
+
+    sin = overload_function(ad_sin, SinBlock)
+    z = AdjFloat(5)
+    _ = sin(z)
+    assert get_blocks_type(tape) == [SinBlock]
+
+    with set_working_tape() as loc_tape:
+        _ = cos(z)
+        assert get_working_tape() == loc_tape
+        assert get_blocks_type(loc_tape) == [CosBlock]
+        assert get_blocks_type(tape) == [SinBlock]


### PR DESCRIPTION
This PR enables to run adjoint computations for vector-valued reduced functional, i.e. resulting from the assembly of a 1-form.

This PR also extends `set_working_tape` to facilitate the usage of local tapes.