### PR TITLE
Fix firedrake_adjoint deprecation warning

### DIFF
--- a/firedrake_adjoint/__init__.py
+++ b/firedrake_adjoint/__init__.py
@@ -1,12 +1,12 @@
 # flake8: noqa
 
+import warnings
+
 from firedrake.adjoint import *
 
 continue_annotation()
 
-raise DeprecationWarning(
-    """The firedrake_adjoint module is deprecated.
+warnings.warn("""The firedrake_adjoint module is deprecated.
 
 Instead, use the firedrake.adjoint module and explicitly start taping
-by calling continue_annotation()."""
-)
+by calling continue_annotation().""", FutureWarning)


### PR DESCRIPTION
Using `raise DeprecationWarning` is incorrect as it terminates the program. Instead one should use `warnings.warn` and use a `FutureWarning` instead of a `DeprecationWarning`.