### PR TITLE
Update ROLObjective to be dualspace-aware

### DIFF
--- a/pyadjoint/optimization/rol_solver.py
+++ b/pyadjoint/optimization/rol_solver.py
@@ -20,8 +20,9 @@ try:
             return self._val
 
         def gradient(self, g, x, tol):
-            self.deriv = self.rf.derivative()
-            g.dat = g.riesz_map(self.deriv)
+            opts = {"riesz_representation": x.inner_product}
+            self.deriv = self.rf.derivative(options=opts)
+            g.dat = Enlist(self.deriv)
 
         def hessVec(self, hv, v, x, tol):
             hessian_action = self.rf.hessian(v.dat)

--- a/pyadjoint/optimization/rol_solver.py
+++ b/pyadjoint/optimization/rol_solver.py
@@ -25,8 +25,9 @@ try:
             g.dat = Enlist(self.deriv)
 
         def hessVec(self, hv, v, x, tol):
-            hessian_action = self.rf.hessian(v.dat)
-            hv.dat = hv.riesz_map(hessian_action)
+            opts = {"riesz_representation": x.inner_product}
+            hessian_action = self.rf.hessian(v.dat, options=opts)
+            hv.dat = Enlist(hessian_action)
 
         def update(self, x, flag, iteration):
             if hasattr(ROL, "UpdateType") and isinstance(flag, ROL.UpdateType):


### PR DESCRIPTION
ROLObjective was deferring to ROLVector to use `_ad_convert_type` (through `ROLVector.riesz_map`) on the result of `rf.derivative()` or `rf.hessian()`. This gives a type error, where a Cofunction is expected. Because (as far as I can tell), the derivative/Hessian operations can return a Riesz representation according to a specific inner product, we should pass this through these calls, instead of a separate `_ad_convert_type` step.

Note that I haven't dealt with the calls to `ROLVector.riesz_map` from ROLConstraint, but perhaps the fix there is equally simple? Hopefully this is the right way to go about making the ROL interface dualspace-aware, anyway.