### PR TITLE
Adjfloat block variables to print saved values.

### DIFF
--- a/pyadjoint/adjfloat.py
+++ b/pyadjoint/adjfloat.py
@@ -123,6 +123,10 @@ class AdjFloat(OverloadedType, float):
     def _ad_copy(self):
         return self
 
+    @property
+    def _ad_str(self):
+        """Return the string of the taped value of this variable."""
+        return str(self.block_variable.saved_output)
 
 _min = min
 _max = max

--- a/pyadjoint/adjfloat.py
+++ b/pyadjoint/adjfloat.py
@@ -128,6 +128,7 @@ class AdjFloat(OverloadedType, float):
         """Return the string of the taped value of this variable."""
         return str(self.block_variable.saved_output)
 
+
 _min = min
 _max = max
 

--- a/pyadjoint/block_variable.py
+++ b/pyadjoint/block_variable.py
@@ -68,7 +68,7 @@ class BlockVariable(object):
         self.save_output(overwrite=overwrite)
 
     def __str__(self):
-        return str(self.output)
+        return str(self.output._ad_str)
 
     @property
     def checkpoint(self):

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -308,6 +308,18 @@ class OverloadedType(object):
         """
         raise NotImplementedError
 
+    def _ad_str(self):
+        """Return the string representation of the block variable.
+
+        For simple scalar types this might be the string representation of the
+        stored value. For more complex objects it is likely to be based on a
+        name attached to this instance.
+
+        Returns:
+            str: A human readable serialisation of this variable.
+        """
+        return str(self)
+
 
 class FloatingType(OverloadedType):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
When printing the numerical value of a block variable, as opposed to printing the original overloaded type, the most logical value to print is the stored value, as this is the value the tape will operate on.

For most types in Firedrake and Dolfin this is irrelevant because it's a symbol that is printed. However, for adjfloat this makes a difference.