### PR TITLE
Remove hint that is not working for python3.8

### DIFF
--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -6,8 +6,6 @@ from contextlib import contextmanager
 from functools import wraps
 from itertools import chain
 from abc import ABC, abstractmethod
-from typing import Optional
-from collections.abc import Iterable
 from .checkpointing import CheckpointManager, CheckpointError
 
 _working_tape = None
@@ -770,9 +768,17 @@ class TimeStepSequence(list):
 
     This behaves like a list of blocks. To access a list of the timesteps, use
     the :attr:`steps` property.
+
+    Args:
+        blocks (list[Block] or TimeStepSequence, optional): If provided, `blocks` can be a list of :class:`Block`
+        or another TimeStepSequence to copy from.
+        steps (list[TimeStep], optional): If provided, `steps` should be a list of :class:`TimeStep` to copy from.
+
+    Atributes:
+        steps (list[TimeStep]): A list of timesteps.
     """
 
-    def __init__(self, blocks=None, steps: Optional[Iterable[Iterable[TimeStep]]] = None):
+    def __init__(self, blocks=None, steps=None):
         # Keep both per-timestep and unified block lists.
         if steps and blocks:
             raise ValueError("set blocks or steps but not both.")

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -5,6 +5,7 @@ import threading
 from contextlib import contextmanager
 from functools import wraps
 from itertools import chain
+from typing import Optional, Iterable
 from abc import ABC, abstractmethod
 from .checkpointing import CheckpointManager, CheckpointError
 
@@ -778,7 +779,7 @@ class TimeStepSequence(list):
         steps (list[TimeStep]): A list of timesteps.
     """
 
-    def __init__(self, blocks=None, steps=None):
+    def __init__(self, blocks=None, steps: Optional[Iterable[Iterable[TimeStep]]] = None):
         # Keep both per-timestep and unified block lists.
         if steps and blocks:
             raise ValueError("set blocks or steps but not both.")

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -775,7 +775,7 @@ class TimeStepSequence(list):
         or another TimeStepSequence to copy from.
         steps (list[TimeStep], optional): If provided, `steps` should be a list of :class:`TimeStep` to copy from.
 
-    Atributes:
+    Attributes:
         steps (list[TimeStep]): A list of timesteps.
     """
 


### PR DESCRIPTION
Fix Python 3.8 issue in `TimeStepSequence` related to the [hint](https://github.com/dolfin-adjoint/pyadjoint/blob/d752d79e4ed9bc39c4822475d8a79627050464a7/pyadjoint/tape.py#L775). This commit aims to address the problem by introducing a class docstring to provide information about the optional `TimeStepSequence` arguments. The issue appears to be related to the `Iterable` type, as demonstrated by the traceback below:

```bash
python3.8 -c "from collections.abc import Iterable; Iterable[list]"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: 'ABCMeta' object is not subscriptable
```

Adding the class docstring aims to enhance clarity and help fix the Python 3.8 compatibility issue.