### PR TITLE
Fixing restart cases that revert

### DIFF
--- a/pyadjoint/optimization/rol_solver.py
+++ b/pyadjoint/optimization/rol_solver.py
@@ -40,9 +40,17 @@ try:
                     self._val = self.rf(x.dat)
                     self._tape_trial = self.rf.tape.checkpoint_block_vars(self.rf.controls)
                 elif flag == ROL.UpdateType.Revert:
-                    # revert back to the cached value
-                    self._val = self._cache
-                    self.rf.tape.restore_block_vars(self._tape_cache)
+                    # If we have cached value revert back to the cached value from _cache
+                    if hasattr(self, "_tape_cache"):
+                        self._val = self._cache
+                        self.rf.tape.restore_block_vars(self._tape_cache)
+                    # else (e.g., when we are unfortunate and restore from a reverted checkpoint)
+                    # repopulate the tape for x.dat, and put them on _cache and _tape_cache
+                    # as they were the last UpdateType.Accept values
+                    else:
+                        self._val = self.rf(x.dat)
+                        self._cache = self._val
+                        self._tape_cache = self._tape_trial
 
                 self._flag = flag
 


### PR DESCRIPTION
This addresses an issue where restoring from a checkpoint coincides with an iteration marked Revert by ROL2.0, triggering a ROL.UpdateType.Revert operation. Previously, this scenario would cause an error when self.rf.tape.restore_block_vars(self._tape_cache) is executed without an available _tape_cache. To resolve this, the implementation now checks for the availability of _tape_cache. If it is not available yet, the tape is recomputed using x.dat, and subsequently, self._tape_cache is updated accordingly.