### PR TITLE
Dolci/add derivative options

### DIFF
--- a/pyadjoint/optimization/optimization.py
+++ b/pyadjoint/optimization/optimization.py
@@ -274,7 +274,7 @@ def maximize(rf, method='L-BFGS-B', scale=1.0, derivative_options=None, **kwargs
         * 'method' specifies the optimization method to be used to solve the problem.
             The available methods can be listed with the print_optimization_methods function.
         * 'scale' is a factor to scale to problem (default: 1.0).
-        * 'derivative_options' is a dictionary of options that can be passed to the derivative function.
+        * 'derivative_options' is a dictionary of options that will be passed to the `rf.derivative`.
         * 'bounds' is an optional keyword parameter to support control constraints: bounds = (lb, ub).
             lb and ub must be of the same type than the parameters m.
 

--- a/pyadjoint/optimization/optimization.py
+++ b/pyadjoint/optimization/optimization.py
@@ -61,8 +61,7 @@ def minimize_scipy_generic(rf_np, method, bounds=None, **kwargs):
     m = [p.tape_value() for p in rf_np.controls]
     m_global = rf_np.obj_to_array(m)
     J = rf_np.__call__
-
-    dJ = lambda m: rf_np.derivative(m, forget=forget, project=project)
+    dJ = lambda m: rf_np.derivative(m, forget=forget, project=project, options=kwargs.get("options", {}))
     H = rf_np.hessian
 
     if "options" not in kwargs:

--- a/pyadjoint/optimization/optimization.py
+++ b/pyadjoint/optimization/optimization.py
@@ -33,7 +33,7 @@ def serialise_bounds(rf_np, bounds):
     return np.array(bounds_arr).T
 
 
-def minimize_scipy_generic(rf_np, method, bounds=None, **kwargs):
+def minimize_scipy_generic(rf_np, method, bounds=None, derivative_options=None, **kwargs):
     """Interface to the generic minimize method in scipy
 
     """
@@ -61,7 +61,7 @@ def minimize_scipy_generic(rf_np, method, bounds=None, **kwargs):
     m = [p.tape_value() for p in rf_np.controls]
     m_global = rf_np.obj_to_array(m)
     J = rf_np.__call__
-    dJ = lambda m: rf_np.derivative(m, forget=forget, project=project, options=kwargs.get("options", {}))
+    dJ = lambda m: rf_np.derivative(m, forget=forget, project=project, options=derivative_options)
     H = rf_np.hessian
 
     if "options" not in kwargs:

--- a/pyadjoint/optimization/optimization.py
+++ b/pyadjoint/optimization/optimization.py
@@ -136,7 +136,7 @@ def minimize_scipy_generic(rf_np, method, bounds=None, derivative_options=None, 
     return m
 
 
-def minimize_custom(rf_np, bounds=None, **kwargs):
+def minimize_custom(rf_np, bounds=None, derivative_options=None, **kwargs):
     """ Interface to the user-provided minimisation method """
 
     try:
@@ -152,7 +152,7 @@ def minimize_custom(rf_np, bounds=None, **kwargs):
     m_global = rf_np.obj_to_array(m)
     J = rf_np.__call__
 
-    dJ = lambda m: rf_np.derivative(m, forget=None)
+    dJ = lambda m: rf_np.derivative(m, forget=None, options=derivative_options)
     H = rf_np.hessian
 
     if bounds is not None:
@@ -255,7 +255,7 @@ def minimize(rf, method='L-BFGS-B', scale=1.0, **kwargs):
         return opt
 
 
-def maximize(rf, method='L-BFGS-B', scale=1.0, **kwargs):
+def maximize(rf, method='L-BFGS-B', scale=1.0, derivative_options=None, **kwargs):
     """ Solves the maximisation problem with PDE constraint:
 
            max_m func(u, m)
@@ -274,6 +274,7 @@ def maximize(rf, method='L-BFGS-B', scale=1.0, **kwargs):
         * 'method' specifies the optimization method to be used to solve the problem.
             The available methods can be listed with the print_optimization_methods function.
         * 'scale' is a factor to scale to problem (default: 1.0).
+        * 'derivative_options' is a dictionary of options that can be passed to the derivative function.
         * 'bounds' is an optional keyword parameter to support control constraints: bounds = (lb, ub).
             lb and ub must be of the same type than the parameters m.
 
@@ -282,7 +283,7 @@ def maximize(rf, method='L-BFGS-B', scale=1.0, **kwargs):
         For detailed information about which arguments are supported for each optimization method,
         please refer to the documentaton of the optimization algorithm.
         """
-    return minimize(rf, method, scale=-scale, **kwargs)
+    return minimize(rf, method, scale=-scale, derivative_options=derivative_options, **kwargs)
 
 
 minimise = minimize

--- a/pyadjoint/reduced_functional_numpy.py
+++ b/pyadjoint/reduced_functional_numpy.py
@@ -55,7 +55,7 @@ class ReducedFunctionalNumPy(ReducedFunctional):
         return numpy.array(m_global, dtype="d")
 
     @no_annotations
-    def derivative(self, m_array=None, forget=True, project=False):
+    def derivative(self, m_array=None, forget=True, project=False, options=None):
         """ An implementation of the reduced functional derivative evaluation
             that accepts the controls as an array of scalars. If no control values are given,
             the result is derivative at the lastest forward run.
@@ -67,7 +67,7 @@ class ReducedFunctionalNumPy(ReducedFunctional):
         # TODO: No good way to check. Is it ok to always assume `m_array` is the same as used last in __call__?
         # if m_array is not None:
         #    self.__call__(m_array)
-        dJdm = self.rf.derivative()
+        dJdm = self.rf.derivative(options=options)
         dJdm = Enlist(dJdm)
 
         m_global = []

--- a/tests/firedrake_adjoint/test_optimisation.py
+++ b/tests/firedrake_adjoint/test_optimisation.py
@@ -7,23 +7,23 @@ from firedrake import *
 from firedrake.adjoint import *
 
 
-# def test_optimisation_constant_control():
-#     """This tests a list of controls in a minimisation (through scipy L-BFGS-B)"""
-#     mesh = UnitSquareMesh(1, 1)
-#     R = FunctionSpace(mesh, "R", 0)
+def test_optimisation_constant_control():
+    """This tests a list of controls in a minimisation (through scipy L-BFGS-B)"""
+    mesh = UnitSquareMesh(1, 1)
+    R = FunctionSpace(mesh, "R", 0)
 
-#     n = 3
-#     x = [Function(R) for i in range(n)]
-#     c = [Control(xi) for xi in x]
+    n = 3
+    x = [Function(R) for i in range(n)]
+    c = [Control(xi) for xi in x]
 
-#     # Rosenbrock function https://en.wikipedia.org/wiki/Rosenbrock_function
-#     # with minimum at x = (1, 1, 1, ...)
-#     f = sum(100*(x[i+1] - x[i]**2)**2 + (1 - x[i])**2 for i in range(n-1))
+    # Rosenbrock function https://en.wikipedia.org/wiki/Rosenbrock_function
+    # with minimum at x = (1, 1, 1, ...)
+    f = sum(100*(x[i+1] - x[i]**2)**2 + (1 - x[i])**2 for i in range(n-1))
 
-#     J = assemble(f * dx(domain=mesh))
-#     rf = ReducedFunctional(J, c)
-#     result = minimize(rf)
-#     assert_allclose([float(xi) for xi in result], 1., rtol=1e-4)
+    J = assemble(f * dx(domain=mesh))
+    rf = ReducedFunctional(J, c)
+    result = minimize(rf)
+    assert_allclose([float(xi) for xi in result], 1., rtol=1e-4)
 
 
 def _simple_helmholz_model(V, source):

--- a/tests/firedrake_adjoint/test_optimisation.py
+++ b/tests/firedrake_adjoint/test_optimisation.py
@@ -2,27 +2,28 @@ import pytest
 pytest.importorskip("firedrake")
 
 from numpy.testing import assert_allclose
+import numpy as np
 from firedrake import *
 from firedrake.adjoint import *
 
 
-def test_optimisation_constant_control():
-    """This tests a list of controls in a minimisation (through scipy L-BFGS-B)"""
-    mesh = UnitSquareMesh(1, 1)
-    R = FunctionSpace(mesh, "R", 0)
+# def test_optimisation_constant_control():
+#     """This tests a list of controls in a minimisation (through scipy L-BFGS-B)"""
+#     mesh = UnitSquareMesh(1, 1)
+#     R = FunctionSpace(mesh, "R", 0)
 
-    n = 3
-    x = [Function(R) for i in range(n)]
-    c = [Control(xi) for xi in x]
+#     n = 3
+#     x = [Function(R) for i in range(n)]
+#     c = [Control(xi) for xi in x]
 
-    # Rosenbrock function https://en.wikipedia.org/wiki/Rosenbrock_function
-    # with minimum at x = (1, 1, 1, ...)
-    f = sum(100*(x[i+1] - x[i]**2)**2 + (1 - x[i])**2 for i in range(n-1))
+#     # Rosenbrock function https://en.wikipedia.org/wiki/Rosenbrock_function
+#     # with minimum at x = (1, 1, 1, ...)
+#     f = sum(100*(x[i+1] - x[i]**2)**2 + (1 - x[i])**2 for i in range(n-1))
 
-    J = assemble(f * dx(domain=mesh))
-    rf = ReducedFunctional(J, c)
-    result = minimize(rf)
-    assert_allclose([float(xi) for xi in result], 1., rtol=1e-4)
+#     J = assemble(f * dx(domain=mesh))
+#     rf = ReducedFunctional(J, c)
+#     result = minimize(rf)
+#     assert_allclose([float(xi) for xi in result], 1., rtol=1e-4)
 
 
 def _simple_helmholz_model(V, source):
@@ -56,3 +57,10 @@ def test_simple_inversion():
 
     x = minimize(rf)
     assert_allclose(x.dat.data, source_ref.dat.data, rtol=1e-2)
+    rf(source)
+    x = minimize(rf, derivative_options={"riesz_representation": "l2"})
+    assert_allclose(x.dat.data, source_ref.dat.data, rtol=1e-2)
+    rf(source)
+    x = minimize(rf, derivative_options={"riesz_representation": "H1"})
+    # Assert that the optimisation does not converge for H1 representation
+    assert not np.allclose(x.dat.data, source_ref.dat.data, rtol=1e-2)


### PR DESCRIPTION
`minimize` has no options for reduced functional derivatives. This PR enables users to add options to compute the adjoint-based derivatives/gradients.