### PR TITLE
Dolci/adj value for minimize

### DIFF
--- a/tests/firedrake_adjoint/test_optimisation.py
+++ b/tests/firedrake_adjoint/test_optimisation.py
@@ -58,9 +58,6 @@ def test_simple_inversion():
     x = minimize(rf)
     assert_allclose(x.dat.data, source_ref.dat.data, rtol=1e-2)
     rf(source)
-    x = minimize(rf, derivative_options={"riesz_representation": "l2"})
-    assert_allclose(x.dat.data, source_ref.dat.data, rtol=1e-2)
-    rf(source)
     x = minimize(rf, derivative_options={"riesz_representation": "H1"})
     # Assert that the optimisation does not converge for H1 representation
     assert not np.allclose(x.dat.data, source_ref.dat.data, rtol=1e-2)


### PR DESCRIPTION
The `Reduced_functional_numpy` class implements the reduced functional for a given functional and controls, using NumPy data structures. This class is particularly useful in the context of the `minimize` function, which relies on SciPy's differentiation algorithms. Additionally, `Reduced_functional_numpy` is designed to integrate seamlessly with any user-provided optimization algorithm.

This PR addresses the scenario where SciPy's `minimize` function requires a non-mapped derivative. The methods `derivative(..., options=None)` and `hessian(..., options=None)` in `Reduced_functional_numpy` will provide these non-mapped derivatives directly when `options=None` is specified, allowing SciPy to use them efficiently. Conversely, users who prefer to apply their optimization algorithms can still utilize `Reduced_functional_numpy` to work with mapped gradients as needed.
