### PR TITLE
Get OverloadType PETSc.vec

### DIFF
--- a/pyadjoint/adjfloat.py
+++ b/pyadjoint/adjfloat.py
@@ -130,9 +130,14 @@ class AdjFloat(OverloadedType, float):
         """Return the string of the taped value of this variable."""
         return str(self.block_variable.saved_output)
 
-    def _ad_petsc_vec(self):
+    def _ad_petsc_vec_write_only(self):
         raise NotImplementedError(
-            "It requires more thought to return a PETSc Vec from `AdjFloat`"
+            "It requires more thought to write only a PETSc Vec from `AdjFloat`."
+        )
+
+    def _ad_petsc_vec_read_only(self):
+        raise NotImplementedError(
+            "It requires more thought to read only a PETSc Vec from `AdjFloat`."
         )
 
 

--- a/pyadjoint/adjfloat.py
+++ b/pyadjoint/adjfloat.py
@@ -130,6 +130,11 @@ class AdjFloat(OverloadedType, float):
         """Return the string of the taped value of this variable."""
         return str(self.block_variable.saved_output)
 
+    def _ad_petsc_vec(self):
+        raise NotImplementedError(
+            "It requires more thought to return a PETSc Vec from `AdjFloat`"
+        )
+
 
 _exp = math.exp
 _log = math.log

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -323,7 +323,7 @@ class OverloadedType(object):
     def _ad_petsc_vec_read_only(self):
         """This method must be overridden.
 
-        The method should implement a routine to return a read only PETSc Vec object.
+        The method should implement a routine to return a read only a PETSc Vec object.
 
         Returns:
             PETSc.Vec: A PETSc Vec object containing the data of the overloaded.
@@ -334,7 +334,7 @@ class OverloadedType(object):
     def _ad_petsc_vec_write_only(self):
         """This method must be overridden.
 
-        The method should implement a routine to return a write only PETSc Vec object.
+        The method should implement a routine to write only a PETSc Vec object.
 
         Returns:
             PETSc.Vec: A PETSc Vec object containing the data of the overloaded.

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -332,7 +332,7 @@ class OverloadedType(object):
         raise NotImplementedError
 
     def _ad_petsc_vec_write_only(self):
-        """This method must be overridden.
+        """This method should be overwritten by types which can return a PETSc Vec.
 
         The method should implement a routine to write only a PETSc Vec object.
 

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -320,10 +320,21 @@ class OverloadedType(object):
         """
         return str(self)
 
-    def _ad_petsc_vec(self):
+    def _ad_petsc_vec_read_only(self):
         """This method must be overridden.
 
-        The method should implement a routine to return a PETSc Vec object.
+        The method should implement a routine to return a read only PETSc Vec object.
+
+        Returns:
+            PETSc.Vec: A PETSc Vec object containing the data of the overloaded.
+
+        """
+        raise NotImplementedError
+
+    def _ad_petsc_vec_write_only(self):
+        """This method must be overridden.
+
+        The method should implement a routine to return a write only PETSc Vec object.
 
         Returns:
             PETSc.Vec: A PETSc Vec object containing the data of the overloaded.

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -321,7 +321,7 @@ class OverloadedType(object):
         return str(self)
 
     def _ad_petsc_vec_read_only(self):
-        """This method must be overridden.
+        """This method should be overwritten by types which can return a PETSc Vec.
 
         The method should implement a routine to return a read only a PETSc Vec object.
 

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -320,6 +320,17 @@ class OverloadedType(object):
         """
         return str(self)
 
+    def _ad_petsc_vec(self):
+        """This method must be overridden.
+
+        The method should implement a routine to return a PETSc Vec object.
+
+        Returns:
+            PETSc.Vec: A PETSc Vec object containing the data of the overloaded.
+
+        """
+        raise NotImplementedError
+
 
 class FloatingType(OverloadedType):
     def __init__(self, *args, **kwargs):

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -323,22 +323,36 @@ class OverloadedType(object):
     def _ad_petsc_vec_read_only(self):
         """This method should be overwritten by types which can return a PETSc Vec.
 
-        The method should implement a routine to return a read only a PETSc Vec object.
+        This method must be used as a context manager.
+
+        Usage:
+
+        .. code-block:: python
+
+                with OverloadedType._ad_petsc_vec_read_only() as vec:
+                    # Do something with vec
 
         Returns:
-            PETSc.Vec: A PETSc Vec object containing the data of the overloaded.
-
+            PETSc.Vec: A PETSc Vec object containing the read-only data of the overloaded
+            instance, excluding halo data.
         """
         raise NotImplementedError
 
     def _ad_petsc_vec_write_only(self):
         """This method should be overwritten by types which can return a PETSc Vec.
 
-        The method should implement a routine to write only a PETSc Vec object.
+        This method must be used as a context manager.
+
+        Usage:
+
+        .. code-block:: python
+
+                with OverloadedType._ad_petsc_vec_write_only() as vec:
+                    # Do something with vec
 
         Returns:
-            PETSc.Vec: A PETSc Vec object containing the data of the overloaded.
-
+            PETSc.Vec: A PETSc Vec object containing the write-only data of the overloaded
+            instance, excluding halo data.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
This PR adds an `OverloadType` method to get the `PETSc.petsc4py.Vec` object.