### PR TITLE
Reverse-over-forward AD

### DIFF
--- a/pyadjoint/__init__.py
+++ b/pyadjoint/__init__.py
@@ -10,7 +10,10 @@ __email__ = 'sebastkm@math.uio.no'
 from .block import Block
 from .tape import (Tape,
                    set_working_tape, get_working_tape, no_annotations,
-                   annotate_tape, stop_annotating, pause_annotation, continue_annotation)
+                   annotate_tape, stop_annotating, pause_annotation, continue_annotation,
+                   no_reverse_over_forward, reverse_over_forward_enabled,
+                   stop_reverse_over_forward, pause_reverse_over_forward,
+                   continue_reverse_over_forward)
 from .adjfloat import AdjFloat, exp, log
 from .reduced_functional import ReducedFunctional
 from .drivers import compute_gradient, compute_hessian, solve_adjoint

--- a/pyadjoint/block.py
+++ b/pyadjoint/block.py
@@ -1,5 +1,7 @@
-from .tape import no_annotations, reverse_over_forward_enabled
+from contextlib import ExitStack
 from html import escape
+
+from .tape import no_annotations, reverse_over_forward_enabled
 
 
 class Block(object):
@@ -84,7 +86,10 @@ class Block(object):
 
         if reverse_over_forward_enabled():
             if len(self._outputs) == self._n_outputs:
-                self.solve_tlm()
+                with ExitStack() as stack:
+                    for output in self._outputs:
+                        stack.enter_context(output.restore_output())
+                    self.solve_tlm()
             elif len(self._outputs) > self._n_outputs:
                 raise RuntimeError("Unexpected output")
 

--- a/pyadjoint/block_variable.py
+++ b/pyadjoint/block_variable.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from .tape import no_annotations, get_working_tape
 
 
@@ -93,3 +95,22 @@ class BlockVariable(object):
         if self.is_control:
             return
         self._checkpoint = value
+
+    @contextmanager
+    def restore_output(self):
+        """Return a context manager which can be used to temporarily restore the
+        value of `self.output` to `self.block_variable.saved_output`.
+
+        Returns:
+            The context manager
+        """
+
+        if self.output is self.saved_output:
+            yield
+        else:
+            old_value = self.output._ad_copy()
+            self.output._ad_assign(self.saved_output)
+            try:
+                yield
+            finally:
+                self._output._ad_assign(old_value)

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -285,6 +285,18 @@ class OverloadedType(object):
         """
         raise NotImplementedError
 
+    def _ad_assign(self, other):
+        """This method must be overridden for mutable types.
+
+        In-place assignment.
+
+        Args:
+            other (object): The object assign to `self`, with the same type as
+                `self`.
+        """
+
+        raise NotImplementedError
+
     def _ad_copy(self):
         """This method must be overridden.
 

--- a/tests/pyadjoint/test_tape.py
+++ b/tests/pyadjoint/test_tape.py
@@ -1,4 +1,13 @@
+import pytest
+
 from pyadjoint import *  # noqa: F403
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _():
+    pause_reverse_over_forward()
+    yield
+    pause_reverse_over_forward()
 
 
 def test_reverse_over_forward_configuration():

--- a/tests/pyadjoint/test_tape.py
+++ b/tests/pyadjoint/test_tape.py
@@ -1,0 +1,29 @@
+from pyadjoint import *  # noqa: F403
+
+
+def test_reverse_over_forward_configuration():
+    assert not reverse_over_forward_enabled()
+
+    continue_reverse_over_forward()
+    assert reverse_over_forward_enabled()
+    pause_reverse_over_forward()
+    assert not reverse_over_forward_enabled()
+
+    continue_reverse_over_forward()
+    assert reverse_over_forward_enabled()
+    with stop_reverse_over_forward():
+        assert not reverse_over_forward_enabled()
+    assert reverse_over_forward_enabled()
+    pause_reverse_over_forward()
+    assert not reverse_over_forward_enabled()
+
+    @no_reverse_over_forward
+    def test():
+        assert not reverse_over_forward_enabled()
+
+    continue_reverse_over_forward()
+    assert reverse_over_forward_enabled()
+    test()
+    assert reverse_over_forward_enabled()
+    pause_reverse_over_forward()
+    assert not reverse_over_forward_enabled()

--- a/tests/pyadjoint/test_tape.py
+++ b/tests/pyadjoint/test_tape.py
@@ -3,7 +3,7 @@ import pytest
 from pyadjoint import *  # noqa: F403
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True)
 def _():
     pause_reverse_over_forward()
     yield


### PR DESCRIPTION
Reverse-over-forward AD.

The usage

```
u = [initialize forward variable]
u.block_variable.tlm_value = [initialize tangent-linear variable]

continue_annotation()
continue_reverse_over_forward()
...
J = [functional]
pause_annotation()
pause_reverse_over_forward()
```

leads to tangent-linear operations being recorded on the tape, allowing a high-order adjoint calculation via e.g.

```
hessian_action = compute_gradient(J.block_variable.tlm_value, Control(u))
```

The primary advantage is that this allows checkpointing at higher-order. The primary disadvantage is that multiple Hessian actions require reruns of the forward and first order adjoint.

API changes:

- Add reverse-over-forward controls `reverse_over_forward_enabled`, `no_reverse_over_forward` (decorator), `stop_reverse_over_forward` (context manager), `pause_reverse_over_forward`, and `continue_reverse_over_forward`.
- Add optional `n_outputs` argument to the `Block` constructor. This is currently required only for reverse-over-forward AD, and is used to trigger tangent-linear operations.
- Add `Block.solve_tlm` method, for performing differentiable tangent-linear operations.
- Add `OverloadedType._ad_assign` for in-place assignment. This is used to temporarily reset forward variables to the required (input) values before performing tangent-linear operations.