### PR TITLE
`ReducedFunctional.optimize_tape` will optionally _replace_ self.tape with the optimized tape, without modifying original tape.

### DIFF
--- a/pyadjoint/control.py
+++ b/pyadjoint/control.py
@@ -80,6 +80,7 @@ class Control(object):
     def fetch_numpy(self, value):
         return self.control._ad_to_list(value)
 
+    # TODO: This should be self.block_variable.checkpoint?
     def copy_data(self):
         return self.control._ad_copy()
 

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -231,6 +231,7 @@ class ReducedFunctional(object):
             controls=self.controls,
             functionals=[self.functional]
         )
+        return self.tape
 
     def marked_controls(self):
         return marked_controls(self)

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -77,7 +77,6 @@ class ReducedFunctional(object):
         if not isinstance(functional, OverloadedType):
             raise TypeError("Functional must be an OverloadedType.")
         self.functional = functional
-        self.tape = get_working_tape() if tape is None else tape
         self.controls = Enlist(controls)
         self.derivative_components = derivative_components
         self.scale = scale
@@ -87,6 +86,13 @@ class ReducedFunctional(object):
         self.derivative_cb_post = derivative_cb_post
         self.hessian_cb_pre = hessian_cb_pre
         self.hessian_cb_post = hessian_cb_post
+
+        tape = get_working_tape() if tape is None else tape
+        self.tape = tape.copy()
+        self.tape.optimize(
+            controls=self.controls,
+            functionals=[self.functional]
+        )
 
         if self.derivative_components:
             # pre callback
@@ -224,13 +230,9 @@ class ReducedFunctional(object):
 
         return func_value
 
-    def optimize_tape(self, replace=False):
-        if replace:
-            self.tape = self.tape.copy()
-        self.tape.optimize(
-            controls=self.controls,
-            functionals=[self.functional]
-        )
+    def optimize_tape(self):
+        # Tape already optimized in __init__
+        # TODO: What should we do here now?
         return self.tape
 
     def marked_controls(self):

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -224,7 +224,9 @@ class ReducedFunctional(object):
 
         return func_value
 
-    def optimize_tape(self):
+    def optimize_tape(self, replace=False):
+        if replace:
+            self.tape = self.tape.copy()
         self.tape.optimize(
             controls=self.controls,
             functionals=[self.functional]

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -383,6 +383,7 @@ class Tape(object):
         )
         if self._checkpoint_manager is not None:
             tape._checkpoint_manager = self._checkpoint_manager
+            tape.latest_checkpoint = self.latest_checkpoint
         if self._bar is not _NullProgressBar:
             tape.progress_bar = self.progress_bar
         return tape


### PR DESCRIPTION
This PR addresses #170 

Currently `ReducedFunctional.optimize_tape` will modify `self.tape` in-place. This means that if anything else is using the same tape, then they now also have a modified tape.

This PR adds an optional `replace` argument to `optimize_tape` to give the option of copying the tape and replacing `self.tape` with the optimized tape, without modifying the original tape. The optimized tape is also returned (whether a copy was made or not).
I did it this way so that the default call has the same behaviour as before, so it shouldn't break any existing code - unless someone is relying on it returning `None`, but seeing as this is implicit and non-documented behaviour I don't think we care.

@dham also suggested that the default behaviour should change so that it doesn't modify `self.tape`, but just returns the optimized tape. Is this something we want to do? If so, should it raise a warning for now that the default behaviour will change in the future, and delay making the change for a bit?
I think if this behaviour does change, it would be good to have an `optimize_tape(modify=False)` argument to optionally still update `self.tape`, otherwise we'll probably see `Jhat.tape = Jhat.optimize_tape()` popping up all over.