### PR TITLE
Mark tape before evaluating TLM, and start hessian accumulation from the correct type.

### DIFF
--- a/pyadjoint/drivers.py
+++ b/pyadjoint/drivers.py
@@ -61,9 +61,12 @@ def compute_hessian(J, m, m_dot, options=None, tape=None):
         m[i].tlm_value = m_dot[i]
 
     with stop_annotating():
-        tape.evaluate_tlm()
+        with tape.marked_nodes(m):
+            tape.evaluate_tlm(markings=True)
 
-    J.block_variable.hessian_value = 0.0
+    J.block_variable.hessian_value = J.block_variable.output._ad_convert_type(
+        0., options={'riesz_representation': None})
+
     with stop_annotating():
         with tape.marked_nodes(m):
             tape.evaluate_hessian(markings=True)

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -361,11 +361,11 @@ class Tape(object):
             ):
                 self._blocks[i].evaluate_adj(markings=markings)
 
-    def evaluate_tlm(self):
+    def evaluate_tlm(self, markings=False):
         for i in self._bar("Evaluating TLM").iter(
             range(len(self._blocks))
         ):
-            self._blocks[i].evaluate_tlm()
+            self._blocks[i].evaluate_tlm(markings=markings)
 
     def evaluate_hessian(self, markings=False):
         for i in self._bar("Evaluating Hessian").iter(


### PR DESCRIPTION
1. Only evaluate the tangent linear model on the relevant blocks.

2. Start accumulating the Hessian values from the zero value of the functional type. This will get changed to use `J.block_variable.output._ad_init_zero()` once #156 is merged.