### PR TITLE
Break `OvertypedType` -> `BlockVariable` -> `OverloadedType` reference cycle

### DIFF
--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -1,3 +1,4 @@
+import weakref
 from .block_variable import BlockVariable
 from .tape import get_working_tape
 
@@ -74,7 +75,7 @@ class OverloadedType(object):
     """
 
     def __init__(self, *args, **kwargs):
-        self.block_variable = None
+        self._block_variable = lambda: None
         self.create_block_variable()
 
     @classmethod
@@ -93,9 +94,18 @@ class OverloadedType(object):
         """
         return cls(obj)
 
+    @property
+    def block_variable(self):
+        block_variable = self._block_variable()
+        return self.create_block_variable() if block_variable is None else block_variable
+
+    @block_variable.setter
+    def block_variable(self, value):
+        self._block_variable = weakref.ref(value)
+
     def create_block_variable(self):
-        self.block_variable = BlockVariable(self)
-        return self.block_variable
+        self.block_variable = block_variable = BlockVariable(self)
+        return block_variable
 
     def _ad_convert_type(self, value, options={}):
         """This method must be overridden.

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -76,7 +76,6 @@ class OverloadedType(object):
 
     def __init__(self, *args, **kwargs):
         self._block_variable = lambda: None
-        self.create_block_variable()
 
     @classmethod
     def _ad_init_object(cls, obj):

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -75,7 +75,7 @@ class OverloadedType(object):
     """
 
     def __init__(self, *args, **kwargs):
-        self._block_variable = lambda: None
+        self.clear_block_variable()
 
     @classmethod
     def _ad_init_object(cls, obj):
@@ -101,6 +101,9 @@ class OverloadedType(object):
     @block_variable.setter
     def block_variable(self, value):
         self._block_variable = weakref.ref(value)
+
+    def clear_block_variable(self):
+        self._block_variable = lambda: None
 
     def create_block_variable(self):
         self.block_variable = block_variable = BlockVariable(self)

--- a/pyadjoint/overloaded_type.py
+++ b/pyadjoint/overloaded_type.py
@@ -66,7 +66,12 @@ def register_overloaded_type(overloaded_type, classes=None):
 
 
 class Weakref:
-    """Weakref which is picklable if the referenced obj is picklable.
+    """Weakref which is picklable if the referenced object is picklable or
+    None.
+
+    Args:
+        obj (:obj:`object`): The object to hold a weak reference to. None
+            indicates a reference to no object.
     """
 
     def __init__(self, obj=None):

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -121,10 +121,10 @@ class stop_annotating(ContextDecorator):
         _annotation_enabled = self._orig_annotation_enabled.pop()
         if self.modifies is not None:
             try:
-                self.modifies.create_block_variable()
+                self.modifies.clear_block_variable()
             except AttributeError:
                 for var in self.modifies:
-                    var.create_block_variable()
+                    var.clear_block_variable()
 
 
 no_annotations = stop_annotating()


### PR DESCRIPTION
Use a `weakref` for `OverloadedType.block_variable`, accessed indirectly via a `property`. The result persists for as long as it is used elsewhere (e.g. on the tape, referenced by a `Control`, etc).

Example use:
```
ot.create_block_variable()
object_0._block_variable = ot.block_variable
object_1._block_variable = ot.block_variable
```
First line creates and then immediately destroys a `BlockVariable`. Second line creates another `BlockVariable`, holding a reference to it, so that the third line references the same `BlockVariable`. Net effect: attach a new `BlockVariable` to `ot`, hold two references on `object_0` and `object_1`, hold a weak reference on `ot`.

Could be optimized by adding an `OverloadedType.clear_block_variable` method to replace the first line of the above example

```
def clear_block_variable(self):
    self._block_variable = lambda: None
```

which avoids the creation and immediate destruction of a `BlockVariable`.