### PR TITLE
Don't use saved_output to create checkpoints for timesteps

### DIFF
--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -826,18 +826,21 @@ class TimeStep(list):
                         # because the global dependencies do not change.
                         self._checkpoint[var] = var._checkpoint
                     else:
-                        self._checkpoint[var] = var.saved_output._ad_create_checkpoint()
+                        var.save_output(overwrite=True)
+                        self._checkpoint[var] = var._checkpoint
 
             if adj_dependencies:
                 if self._revised_adj_deps:
                     for var in self.adjoint_dependencies:
-                        self._checkpoint[var] = var.saved_output._ad_create_checkpoint()
+                        var.save_output(overwrite=True)
+                        self._checkpoint[var] = var._checkpoint
                 else:
                     # The adjoint dependencies have not been revised yet. At this stage,
                     # the block nodes are not marked in the path because the control variable(s)
                     # are not yet determined.
                     for var in self.adjoint_dependencies.union(self.checkpointable_state):
-                        self._checkpoint[var] = var.saved_output._ad_create_checkpoint()
+                        var.save_output(overwrite=True)
+                        self._checkpoint[var] = var._checkpoint
 
     def restore_from_checkpoint(self, from_storage):
         """Restore the block var checkpoints from the timestep checkpoint."""


### PR DESCRIPTION
We have a few blocks, `T` (the BC function) <- `AssignBlock` (for T += 1), <- `DirichletBCBlock` <- `AssignBlock` <- `DirichletBCBlock`. At the end of timestep 0 (or the beginning of timestep 1), we have the first 3 of these blocks on tape. During the `add_dependency` phase of the solve, the `DirichletBCBlock` was also checkpointed, so its associated block variable has a `_checkpoint` member which is just the `T` function (https://github.com/firedrakeproject/firedrake/blob/a9f2c621633f0e56c69c9ab42c6f2343051f4839/firedrake/adjoint_utils/dirichletbc.py#L36-L43)

Now, when timestep 1 is due to begin, the `process_taping` method checkpoints all the blocks:
https://github.com/dolfin-adjoint/pyadjoint/blob/0b1348021fb3bc69504e3e7ec4f90f21ba1b3822/pyadjoint/checkpointing.py#L203-L204

This process goes through the `saved_output` property:
https://github.com/dolfin-adjoint/pyadjoint/blob/0b1348021fb3bc69504e3e7ec4f90f21ba1b3822/pyadjoint/tape.py#L839-L840

Let's consider when `var` here is the block variable associated with the `DirichletBC`. The `saved_output` property will use the existing checkpoint:
https://github.com/dolfin-adjoint/pyadjoint/blob/0b1348021fb3bc69504e3e7ec4f90f21ba1b3822/pyadjoint/block_variable.py#L57-L62

This has the effect of calling `DirichletBCMixin._ad_restore_at_checkpoint` on a _checkpointed function_: https://github.com/firedrakeproject/firedrake/blob/a9f2c621633f0e56c69c9ab42c6f2343051f4839/firedrake/adjoint_utils/dirichletbc.py#L45-L48

Because of the use of `set_value` here, the `DirichletBC` is then **modified** (and refers to the _previous_ value of `T`). It seems like the weak checkpointing in `DirichletBC` is probably correct, which points to the accessing of `saved_output` during `TimeStep.checkpoint` being incorrect. I'm really unclear about what's checkpointed and when and when to use `.output` vs. `.saved_output`, etc. I don't know if there are further implications for this change.