### PR TITLE
Factor the TLM calculation out of Hessian calculation

### DIFF
--- a/pyadjoint/drivers.py
+++ b/pyadjoint/drivers.py
@@ -81,7 +81,7 @@ if deprecated is not None:
     )(compute_gradient)
 
 
-def compute_hessian(J, m, m_dot, tape=None, apply_riesz=False):
+def compute_hessian(J, m, m_dot, hessian_input=None, tape=None, evaluate_tlm=True, apply_riesz=False):
     """
     Compute the Hessian of J in a direction m_dot at the current value of m
 
@@ -90,10 +90,15 @@ def compute_hessian(J, m, m_dot, tape=None, apply_riesz=False):
         m (list or instance of Control): The (list of) controls.
         m_dot (list or instance of the control type): The direction in which to
             compute the Hessian.
+        hessian_input (OverloadedType): The value to start the Hessian accumulation
+            from after the TLM calculation. Uses zero initialised value if None.
         tape: The tape to use. Default is the current tape.
         apply_riesz: If True, apply the Riesz map of each control in order
             to return the (primal) Riesz representer of the Hessian
             action.
+        evaluate_tlm (bool): Whether or not to compute the forward (TLM) part of
+            the Hessian calculation.  If False, assumes that the tape has already
+            been populated with the required TLM values.
 
     Returns:
         OverloadedType: The action of the Hessian in the direction m_dot.
@@ -103,27 +108,57 @@ def compute_hessian(J, m, m_dot, tape=None, apply_riesz=False):
     """
     tape = tape or get_working_tape()
 
-    tape.reset_tlm_values()
+    # fill the relevant tlm values on the tape
+    if evaluate_tlm:
+        compute_tlm(J, m, m_dot, tape)
+
     tape.reset_hessian_values()
 
+    if hessian_input is None:
+        J.block_variable.hessian_value = (
+            J.block_variable.output._ad_init_zero(dual=True))
+    else:
+        J.block_variable.hessian_value = (
+            J.block_variable.output._ad_init_object(hessian_input))
+
     m = Enlist(m)
-    m_dot = Enlist(m_dot)
-    for i, value in enumerate(m_dot):
-        m[i].tlm_value = m_dot[i]
-
-    with stop_annotating():
-        with tape.marked_nodes(m):
-            tape.evaluate_tlm(markings=True)
-
-    J.block_variable.hessian_value = (
-        J.block_variable.output._ad_init_zero(dual=True))
-
     with stop_annotating():
         with tape.marked_nodes(m):
             tape.evaluate_hessian(markings=True)
 
     r = [v.get_hessian(apply_riesz=apply_riesz) for v in m]
     return m.delist(r)
+
+
+def compute_tlm(J, m, m_dot, tape=None):
+    """
+    Compute the tangent linear model of J in a direction m_dot at the current value of m
+
+    Args:
+        J (OverloadedType):  The objective functional.
+        m (list or instance of Control): The (list of) controls.
+        m_dot (list or instance of the control type): The direction in which to
+            compute the tangent linear model.
+        tape: The tape to use. Default is the current tape.
+
+    Returns:
+        OverloadedType: The action of the tangent linear model with respect to the control
+            in direction m_dot. Should be an instance of the same type as the functional.
+    """
+    tape = tape or get_working_tape()
+    tape.reset_tlm_values()
+
+    m = Enlist(m)
+    m_dot = Enlist(m_dot)
+
+    for mi, mdi in zip(m, m_dot):
+        mi.tlm_value = mdi
+
+    with stop_annotating():
+        with tape.marked_nodes(m):
+            tape.evaluate_tlm(markings=True)
+
+    return J._ad_init_object(J.block_variable.tlm_value)
 
 
 def solve_adjoint(J, tape=None, adj_value=1.0):

--- a/pyadjoint/drivers.py
+++ b/pyadjoint/drivers.py
@@ -157,7 +157,7 @@ def compute_tlm(J, m, m_dot, tape=None):
         mi.tlm_value = mdi
 
     with stop_annotating():
-        with tape.marked_nodes(m):
+        with tape.marked_control_dependents(m):
             tape.evaluate_tlm(markings=True)
 
     return J._ad_init_object(J.block_variable.tlm_value)

--- a/pyadjoint/reduced_functional.py
+++ b/pyadjoint/reduced_functional.py
@@ -82,7 +82,7 @@ class AbstractReducedFunctional(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def hessian(self, m_dot, apply_riesz=False):
+    def hessian(self, m_dot, hessian_input=None, evaluate_tlm=True, apply_riesz=False):
         """Return the action of the Hessian of the functional.
 
         The Hessian is evaluated w.r.t. the control on a vector m_dot.
@@ -94,7 +94,13 @@ class AbstractReducedFunctional(ABC):
         Args:
             m_dot ([OverloadedType]): The direction in which to compute the
                 action of the Hessian.
-            apply_riesz: If True, apply the Riesz map of each control in order
+            hessian_input OverloadedType: The Hessian value for the functional result.
+                Required if the functional is not scalar-valued, or if the functional
+                is an intermediate result in the computation of an outer functional.
+            evaluate_tlm (bool): If True, will evaluate the tangent linear model before
+                evaluating the Hessian. If False, assumes that the tape is already
+                populated with the tangent linear values and does not evaluate them.
+            apply_riesz (bool): If True, apply the Riesz map of each control in order
                 to return the (primal) Riesz representer of the Hessian
                 action.
 

--- a/pyadjoint/reduced_functional_numpy.py
+++ b/pyadjoint/reduced_functional_numpy.py
@@ -66,7 +66,8 @@ class ReducedFunctionalNumPy(AbstractReducedFunctional):
                 "ReducedFunctionalNumpy only returns primal gradients."
             )
 
-        dJdm = self.rf.derivative(adj_input, apply_riesz)
+        dJdm = self.rf.derivative(adj_input=adj_input,
+                                  apply_riesz=apply_riesz)
         dJdm = Enlist(dJdm)
 
         m_global = []
@@ -89,7 +90,7 @@ class ReducedFunctionalNumPy(AbstractReducedFunctional):
         self.derivative()
         m_copies = [control.copy_data() for control in self.controls]
         Hm = self.rf.hessian(self.set_local(m_copies, m_dot_array),
-                             apply_riesz)
+                             apply_riesz=apply_riesz)
         Hm = Enlist(Hm)
 
         m_global = []
@@ -102,6 +103,17 @@ class ReducedFunctionalNumPy(AbstractReducedFunctional):
         tape.reset_variables()
 
         return numpy.array(m_global, dtype="d")
+
+    @no_annotations
+    def tlm(self, m_dot_array):
+        m_copies = [control.copy_data() for control in self.controls]
+        tm = self.rf.tlm(self.set_local(m_copies, m_dot_array))
+        tm_global = self.functional._ad_to_list(tm)
+
+        tape = get_working_tape()
+        tape.reset_variables()
+
+        return numpy.array(tm_global, dtype="d")
 
     def obj_to_array(self, obj):
         return self.get_global(obj)

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -542,7 +542,7 @@ class Tape(object):
         finally:
             for node in nodes:
                 node.is_functional_dependency = False
- 
+
     def _functional_dependencies(self, functional):
         # This function is just a stripped down Block.optimize_for_controls
         nodes = set([functional.block_variable])


### PR DESCRIPTION
Currently there is no way of asking pyadjoint to calculate the action of the TLM unless it's as part of the Hessian action.
This PR just make the TLM action a first class citizen like the adjoint and Hessian, with a driver and a `ReducedFunctional` method of its own.