### PR TITLE
Do not use a Riesz map in the `scipy.optimize.minimize` interface

### DIFF
--- a/pyadjoint/optimization/optimization.py
+++ b/pyadjoint/optimization/optimization.py
@@ -59,7 +59,7 @@ def minimize_scipy_generic(rf_np, method, bounds=None, **kwargs):
     m = [p.tape_value() for p in rf_np.controls]
     m_global = rf_np.obj_to_array(m)
     J = rf_np.__call__
-    dJ = lambda m: rf_np.derivative(apply_riesz=True)
+    dJ = lambda m: rf_np.derivative()
     H = lambda x, p: rf_np.hessian(p)
 
     if "options" not in kwargs:
@@ -153,7 +153,7 @@ def minimize_custom(rf_np, bounds=None, **kwargs):
     m_global = rf_np.obj_to_array(m)
     J = rf_np.__call__
 
-    dJ = lambda m: rf_np.derivative(m, apply_riesz=True)
+    dJ = lambda m: rf_np.derivative(m)
     H = rf_np.hessian
 
     if bounds is not None:


### PR DESCRIPTION
At least for L-BFGS-B using any Riesz map other than $l_2$ is mathematically incorrect.

Closes #153.