### PR TITLE
Ignore `FutureWarning` when testing `compute_gradient`

### DIFF
--- a/pyadjoint/__init__.py
+++ b/pyadjoint/__init__.py
@@ -14,7 +14,7 @@ from .optimization.optimization import (
 from .control import Control
 from .overloaded_type import OverloadedType, create_overloaded_object
 from .verification import taylor_test, taylor_to_dict
-from .drivers import compute_gradient, compute_hessian, solve_adjoint
+from .drivers import compute_gradient, compute_derivative, compute_tlm, compute_hessian, solve_adjoint
 from .checkpointing import disk_checkpointing_callback
 from .reduced_functional import ReducedFunctional
 from .adjfloat import AdjFloat, exp, log
@@ -57,6 +57,8 @@ __all__ = [
     "create_overloaded_object",
     "OverloadedType",
     "compute_gradient",
+    "compute_derivative",
+    "compute_tlm",
     "compute_hessian",
     "solve_adjoint",
     "taylor_test",

--- a/tests/pyadjoint/test_enlisting.py
+++ b/tests/pyadjoint/test_enlisting.py
@@ -1,5 +1,8 @@
 from pyadjoint import *
+import pytest
 
+
+@pytest.mark.filterwarnings("ignore:compute_gradient:FutureWarning")
 def test_compute_gradient():
     a = AdjFloat(1.0)
     b = AdjFloat(2.0)
@@ -8,6 +11,16 @@ def test_compute_gradient():
     c = Control(a)
     assert isinstance(compute_gradient(J, c), AdjFloat)
     assert isinstance(compute_gradient(J, [c]), list)
+
+
+def test_compute_derivative():
+    a = AdjFloat(1.0)
+    b = AdjFloat(2.0)
+
+    J = a*b
+    c = Control(a)
+    assert isinstance(compute_derivative(J, c), AdjFloat)
+    assert isinstance(compute_derivative(J, [c]), list)
 
 
 def test_reduced_functional():


### PR DESCRIPTION
Also adds the newer `compute_derivative` and `compute_tlm` drivers to the top level API with `compute_gradient` and `compute_hessian`.