### PR TITLE
`set_working_tape` switches on annotation

### DIFF
--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -73,7 +73,7 @@ class set_working_tape(ContextDecorator):
 
     """
 
-    def __init__(self, tape=None, **tape_kwargs):
+    def __init__(self, tape=None, continue_annotation=True, **tape_kwargs):
         # Get working tape
         global _working_tape
         # Store current tape
@@ -81,14 +81,20 @@ class set_working_tape(ContextDecorator):
         # Set new tape
         self.tape = tape or Tape(**tape_kwargs)
         _working_tape = self.tape
+        self._continue_annotation = continue_annotation
 
     def __enter__(self):
+        if self._continue_annotation:
+            self._was_annotating = annotate_tape()
+            continue_annotation()
         return self.tape
 
     def __exit__(self, *args):
         # Re-establish the original tape
         global _working_tape
         _working_tape = self.old_tape
+        if self._continue_annotation and not self._was_annotating:
+            pause_annotation()
 
 
 class stop_annotating(ContextDecorator):

--- a/pyadjoint/tape.py
+++ b/pyadjoint/tape.py
@@ -73,7 +73,7 @@ class set_working_tape(ContextDecorator):
 
     """
 
-    def __init__(self, tape=None, continue_annotation=True, **tape_kwargs):
+    def __init__(self, tape=None, continue_annotation=False, **tape_kwargs):
         # Get working tape
         global _working_tape
         # Store current tape


### PR DESCRIPTION
If annotations are switched off and you use the `set_working_tape` context manager then nothing gets taped, which can be confusing and/or inconvenient in some circumstances (e.g. if you are inside some function/library and annotation was switched off above you in the stack).

We're also trying to move to `set_working_tape` being the best-practice to limit the scope of each tape, so you end up writing things like:

```python
was_annotating = annotate_tape()
continue_annotation()
with set_working_tape() as tape:
	...
if not was_annotating:
	pause_annotation()
```

This PR makes `set_working_tape` do the logic to a) make sure we have annotations on inside the context manager and b) return the annotation state to the value before the context manager. The above code just becomes:
```python
with set_working_tape() as tape:
	...
```
The previous behaviour can be obtained by setting the `continue_annotations` kwarg
```python
with set_working_tape(continue_annotations=False) as tape:
	...
```