### PR TITLE
Fix SingleMemoryStorageSchedule checkpoint clearing during forward replay

### DIFF
--- a/pyadjoint/checkpointing.py
+++ b/pyadjoint/checkpointing.py
@@ -361,7 +361,7 @@ class CheckpointManager:
 
                 # Handle the case for SingleMemoryStorageSchedule
                 if isinstance(self._schedule, SingleMemoryStorageSchedule):
-                    if step > 1 and var not in self.tape.timesteps[step - 1].adjoint_dependencies:
+                    if var.output.block_variable is var:
                         var.checkpoint = None
                     continue
 

--- a/pyadjoint/checkpointing.py
+++ b/pyadjoint/checkpointing.py
@@ -361,7 +361,16 @@ class CheckpointManager:
 
                 # Handle the case for SingleMemoryStorageSchedule
                 if isinstance(self._schedule, SingleMemoryStorageSchedule):
-                    if var.output.block_variable is var:
+                    # `var` is used by a block in this step, so the adjoint of
+                    # this step may still need it as a linearisation point.
+                    # Only clear once the adjoint dependencies have been
+                    # revised by a reverse pass and `var` is provably not one
+                    # of them; before that, keeping every dependency in memory
+                    # is exactly what this schedule promises.
+                    if (
+                        current_step._revised_adj_deps
+                        and var not in current_step.adjoint_dependencies
+                    ):
                         var.checkpoint = None
                     continue
 

--- a/pyadjoint/checkpointing.py
+++ b/pyadjoint/checkpointing.py
@@ -366,7 +366,10 @@ class CheckpointManager:
                     # Only clear once the adjoint dependencies have been
                     # revised by a reverse pass and `var` is provably not one
                     # of them; before that, keeping every dependency in memory
-                    # is exactly what this schedule promises.
+                    # is exactly what this schedule promises. The trade-off is
+                    # that a forward-only recomputation retains the conservative
+                    # dependency set and so holds taping-time memory; the more
+                    # precise clearing only takes effect after the first reverse.
                     if (
                         current_step._revised_adj_deps
                         and var not in current_step.adjoint_dependencies


### PR DESCRIPTION
## Summary

Fixes #211. Fixes #260.

Both issues come from the same spot: during forward replay, the `SingleMemoryStorageSchedule` branch of the checkpoint clearing decides at a variable's last forward use whether its checkpoint can be discarded, and got this wrong in two ways.

For #211, the condition consulted the previous step's `adjoint_dependencies`, which are only fully populated during the reverse pass, so a long-range dependency (a variable reused, say, every third step) was cleared during replay and the reverse pass produced a wrong gradient. The first commit here replaced that with an identity check keeping superseded block variables alive. But that still cleared variables that remain the live block variable of their Function, relying on `saved_output` falling back to the live object — which holds the value from taping, not from the replay. As #260 shows, the adjoint of the last-use step still needs the variable as a linearisation point, so re-evaluating the functional at a new control before calling `derivative()` corrupts the gradient, which is precisely what every optimisation loop does.

The end state is a single condition covering both: a variable visited here is by construction a dependency of a block in this step, so its checkpoint is only cleared once the step's adjoint dependencies have been revised by a reverse pass and the variable is provably not among them. Before that everything is kept, which is exactly what "all adjoint dependencies are stored in memory" promises. The clear still goes through the public `checkpoint` setter, so the `is_control` guard from #257 protects control values on this path.

## Test

Against the #211 MFE the gradient matches the unscheduled tape (3205.30164... in both cases, where master gives 73765.11...). Against the #260 MFE the gradient at a new control is 187.4048 with and without the schedule, where master gives 140.5536; the step-1-last-use variant and a second evaluate/derivative cycle also agree. A control's value still survives clearing under this schedule (four timesteps of `J = sum_k m**2` at `m = 2` give `J = dJ/dm = 16`), and all 218 pyadjoint unit tests pass. Regression tests for both issues live in firedrakeproject/firedrake#5168.
