### PR TITLE
Add a warning in `taylor_to_dict` if the minimum residual is close to machine precision.

### DIFF
--- a/pyadjoint/verification.py
+++ b/pyadjoint/verification.py
@@ -144,6 +144,8 @@ def taylor_to_dict(J, m, h):
 
         for key in error_dict.keys():
             if key != "eps":
+                if min(error_dict[key]["Residual"])< 1E-15:
+                    logging.warning("The taylor remainder for {} is close to machine precision.".format(key))
                 error_dict[key]["Rate"] = convergence_rates(error_dict[key]
                                                             ["Residual"][:],
                                                             error_dict["eps"],


### PR DESCRIPTION
This warning is present in `taylor_test`,
``` python3
if min(residuals) < 1E-15:
            logging.warning("The taylor remainder is close to machine precision.")
```
but not in `taylor_to_dict`.