### PR TITLE
switch off annotations in tao solver

### DIFF
--- a/pyadjoint/optimization/tao_solver.py
+++ b/pyadjoint/optimization/tao_solver.py
@@ -777,6 +777,17 @@ class TAOSolver(OptimizationSolver):
 
         return self._x
 
+    @cached_property
+    def _tao_reasons(self):
+        """Dictionary of TAO convergence reason int codes -> python objects
+        """
+        from petsc4py import PETSc
+        # Same approach as in _make_reasons in firedrake/solving_utils.py,
+        # Firedrake master branch 57e21cc8ebdb044c1d8423b48f3dbf70975d5548
+        return {getattr(PETSc.TAO.Reason, key): key
+                for key in dir(PETSc.TAO.Reason)
+                if not key.startswith("_")}
+
     @no_annotations
     def solve(self):
         """Solve the optimization problem.

--- a/pyadjoint/optimization/tao_solver.py
+++ b/pyadjoint/optimization/tao_solver.py
@@ -7,6 +7,7 @@ from ..enlisting import Enlist
 from ..overloaded_type import OverloadedType
 from .optimization_problem import MinimizationProblem
 from .optimization_solver import OptimizationSolver
+from ..tape import no_annotations
 
 
 try:
@@ -795,6 +796,7 @@ class TAOSolver(OptimizationSolver):
 
         return self._x
 
+    @no_annotations
     def solve(self):
         """Solve the optimization problem.
 


### PR DESCRIPTION
Otherwise we end up taping the `riesz_representation` calls in various places in the TAO callbacks.