### PR TITLE
Riesz map pc

### DIFF
--- a/pyadjoint/optimization/__init__.py
+++ b/pyadjoint/optimization/__init__.py
@@ -7,3 +7,7 @@ __credits__ = ['Patrick Farrell', 'Simon Funke', 'David Ham', 'Marie Rognes']
 __license__ = 'LGPL-3'
 __maintainer__ = 'Simon Funke'
 __email__ = 'simon@simula.no'
+
+from .tao_solver import RieszMapPC
+
+__all__ = ["RieszMapPC"]

--- a/pyadjoint/optimization/tao_solver.py
+++ b/pyadjoint/optimization/tao_solver.py
@@ -873,8 +873,6 @@ class RieszMapPC(PCBase):
         if viewer.getType() != PETSc.Viewer.Type.ASCII:
             return
 
-        viewer.printfASCII(
-            f"  Riesz map preconditioner: {type(self).__name__}\n")
+        viewer.printfASCII(f"  Riesz map preconditioner: {type(self).__name__}\n")
         for control in self.controls:
-            viewer.printfASCII(
-                f"  applying the {control.riesz_map} Riesz map\n")
+            viewer.printfASCII(f"  applying the {control.riesz_map} Riesz map\n")

--- a/pyadjoint/optimization/tao_solver.py
+++ b/pyadjoint/optimization/tao_solver.py
@@ -873,6 +873,8 @@ class RieszMapPC(PCBase):
         if viewer.getType() != PETSc.Viewer.Type.ASCII:
             return
 
-        viewer.printfASCII(f"  Riesz map preconditioner: {type(self).__name__}\n")
+        viewer.pushASCIITab()
+        viewer.printfASCII(f"Riesz map preconditioner: {type(self).__name__}\n")
         for control in self.controls:
-            viewer.printfASCII(f"  applying the {control.riesz_map} Riesz map\n")
+            viewer.printfASCII(f"applying the {control.riesz_map} Riesz map\n")
+        viewer.popASCIITab()

--- a/pyadjoint/optimization/tao_solver.py
+++ b/pyadjoint/optimization/tao_solver.py
@@ -9,10 +9,26 @@ from ..overloaded_type import OverloadedType
 from .optimization_problem import MinimizationProblem
 from .optimization_solver import OptimizationSolver
 
+try:
+    from petsctools import PCBase
+except ImportError:
+    class PCBase:
+        """Fallback base class used when petsctools is not installed.
+
+        Keeps RieszMapPC importable (e.g. for documentation) when
+        petsctools is unavailable. The preconditioner cannot be used
+        without it, so instantiating it raises a clear error.
+        """
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "RieszMapPC requires petsctools, which is not installed"
+            )
+
 
 __all__ = [
     "TAOConvergenceError",
-    "TAOSolver"
+    "TAOSolver",
+    "RieszMapPC"
 ]
 
 
@@ -812,3 +828,56 @@ class TAOSolver(OptimizationSolver):
             return controls.delist(m)
         else:
             return m
+
+
+class RieszMapPC(PCBase):
+    """
+    PETSc.PC Python context to apply the Riesz map as a preconditioner.
+
+    Applies the Riesz map to the dual vector supplied by the inner KSP and
+    returns its primal representation. Intended to precondition the reduced
+    Hessian solve of TAO/NLS, whose action maps the control space to its dual.
+
+    If V is the control space then the preconditioner has the signature:
+    RieszMap : V* -> V
+
+    The Riesz map applied is read from the `riesz_map` attribute of each
+    Control. The P matrix must be a PETSc.Mat whose python context is a
+    ReducedFunctionalHessianMat.
+    """
+    needs_python_pmat = True
+    prefix = "riesz"
+
+    def initialize(self, pc):
+        if not isinstance(self.pmat, ReducedFunctionalHessianMat):
+            raise TypeError(
+                "RieszMapPC needs a ReducedFunctionalHessianMat")
+
+        self.controls = self.pmat.rf.controls
+        self.vec_interface = self.pmat.control_interface
+        self.dJ = tuple(c._ad_init_zero(dual=True)
+                        for c in self.controls)
+
+    def apply(self, pc, x, y):
+        self.vec_interface.from_petsc(x, self.dJ)
+        gradJ = tuple(c._ad_convert_riesz(dJi, riesz_map=c.riesz_map)
+                      for c, dJi in zip(self.controls, self.dJ))
+        self.vec_interface.to_petsc(y, gradJ)
+
+    def update(self, pc):
+        pass
+
+    def view(self, pc, viewer=None):
+        """View object. Method usually called by PETSc with e.g. -tao_view.
+        """
+        from petsc4py import PETSc
+        if viewer is None:
+            return
+        if viewer.getType() != PETSc.Viewer.Type.ASCII:
+            return
+
+        viewer.printfASCII(
+            f"  Riesz map preconditioner: {type(self).__name__}\n")
+        for control in self.controls:
+            viewer.printfASCII(
+                f"  applying the {control.riesz_map} Riesz map\n")

--- a/pyadjoint/optimization/tao_solver.py
+++ b/pyadjoint/optimization/tao_solver.py
@@ -832,17 +832,14 @@ class TAOSolver(OptimizationSolver):
 
 class RieszMapPC(PCBase):
     """
-    PETSc.PC Python context to apply the Riesz map as a preconditioner.
+    PETSc.PC Python context to apply the Riesz map as a preconditioner for the
+    reduced Hessian solve of TAO/NLS.
 
-    Applies the Riesz map to the dual vector supplied by the inner KSP and
-    returns its primal representation. Intended to precondition the reduced
-    Hessian solve of TAO/NLS, whose action maps the control space to its dual.
-
-    If V is the control space then the preconditioner has the signature:
+    If V is the control space, the preconditioner has the map:
     RieszMap : V* -> V
 
-    The Riesz map applied is read from the `riesz_map` attribute of each
-    Control. The P matrix must be a PETSc.Mat whose python context is a
+    The Riesz map is read from the `riesz_map` attribute of each Control. The
+    preconditioning matrix must be a PETSc.Mat whose python context is a
     ReducedFunctionalHessianMat.
     """
     needs_python_pmat = True


### PR DESCRIPTION
This adds RieszMapPC, a preconditioner for the inner Krylov solve of pyadjoint's TAO Newton optimiser (tao_type nls). In these problems the gradient lives in the dual of the control space, but PETSc by default treats it as if it lived in the control space itself, and that mismatch makes the inner solve take more iterations as the mesh gets finer. RieszMapPC fixes this by applying the Riesz map (the correct dual-to-primal conversion, from each Control's riesz_map, e.g. "L2") as the preconditioner, which keeps the inner iteration count roughly mesh-independent, provided the Riesz map matches the norm in which the control is regularised.
