### PR TITLE
Bump pyadjoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyadjoint-ad"
-version = "2026.4.1"
+version = "2026.10.0"
 dependencies = [
   "checkpoint_schedules",
   "scipy>=1.0",


### PR DESCRIPTION
Prepare new release that includes https://github.com/dolfin-adjoint/pyadjoint/pull/257 which would be good for checkpointing on our end.

Note:
We should start using dev0, dev1 tags on the master branch to distinguish main branch and stable releases.